### PR TITLE
Saving state of bSearchable in cookie

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -5872,6 +5872,14 @@
 				sValue += oSettings.aoColumns[i].bVisible+",";
 			}
 			sValue = sValue.substring(0, sValue.length-1);
+			sValue += "],";
+			
+			sValue += '"abSearchCols":[ ';
+			for ( i=0 ; i<oSettings.aoColumns.length ; i++ )
+			{
+				sValue += oSettings.aoColumns[i].bSearchable+",";
+			}
+			sValue = sValue.substring(0, sValue.length-1);
 			sValue += "]";
 			
 			/* Save state from any plug-ins */
@@ -5979,6 +5987,21 @@
 						oInit.saved_aoColumns[i].bVisible = oData.abVisCols[i];
 					}
 				}
+
+				if ( typeof oData.abSearchCols != 'undefined' )
+				{
+					/* Pass back visibiliy settings to the init handler, but to do not here override
+					 * the init object that the user might have passed in
+					 */
+					for ( i=0 ; i<oData.abSearchCols.length ; i++ )
+					{
+						if ( typeof oInit.saved_aoColumns[i] == 'undefined' )
+							oInit.saved_aoColumns[i] = {};
+						
+						oInit.saved_aoColumns[i].bSearchable = oData.abSearchCols[i];
+					}
+				}
+								
 			}
 		}
 		
@@ -6675,6 +6698,7 @@
 						aoColumnsInit[i] = {};
 					}
 					aoColumnsInit[i].bVisible = oInit.saved_aoColumns[i].bVisible;
+					aoColumnsInit[i].bSearchable = oInit.saved_aoColumns[i].bSearchable;
 				}
 				
 				_fnAddColumn( oSettings, anThs ? anThs[i] : null );


### PR DESCRIPTION
Hi,

I had the requirement to save bSearchable in the cookie so the search criteria will match propperly the next time the table ist reinitialized. As far as I could see it was not possible to implement this via the API or the callbacks, so I descided to modify the library.

I hope I was able to do it in an unintrusive way.

I would be very happy if the feature would be included in the main branch. Please feel free to use this patch.

Regards
 Roman
