### PR TITLE
Fixed bugs in fnGetNodes and fnGetData

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -1762,7 +1762,7 @@
 			{
 				var iRow = (typeof mRow == 'object') ? 
 					_fnNodeToDataIndex(oSettings, mRow) : mRow;
-				return oSettings.aoData[iRow]._aData;
+				return ( (aRowData = oSettings.aoData[iRow]) ? aRowData._aData : null);
 			}
 			return _fnGetDataMaster( oSettings );
 		};
@@ -1782,7 +1782,7 @@
 			
 			if ( typeof iRow != 'undefined' )
 			{
-				return oSettings.aoData[iRow].nTr;
+				return ( (aRowData = oSettings.aoData[iRow]) ? aRowData.nTr : null );
 			}
 			return _fnGetTrNodes( oSettings );
 		};


### PR DESCRIPTION
I fixed a pair of bugs in fnGetNodes and fnGetData.  With this patch, when either of these methods are called with an integer that is out of range for the array oSettings.aoData, it will return null instead of raising an error.
