### PR TITLE
The Search / Filter box should have a label.

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -4185,7 +4185,7 @@
 		 */
 		function _fnFeatureHtmlFilter ( oSettings )
 		{
-			var nFilter = document.createElement( 'div' );
+			var nFilter = document.createElement( 'label' );
 			if ( oSettings.sTableId !== '' && typeof oSettings.aanFeatures.f == "undefined" )
 			{
 				nFilter.setAttribute( 'id', oSettings.sTableId+'_filter' );


### PR DESCRIPTION
Makes it more accessible for keyboard users, and for people who use a mouse adds the ability to click the text next to the field to focus the element - which is useful.

A label should offer just as much styling opportunity as a div. If this isn't an acceptable soultion, one could create a new label element within the exisiting div, and make it point to the input.
