### PR TITLE
Add bSortMulti option to disallow multiple-column sorting

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -918,6 +918,7 @@
 				"bLengthChange": true,
 				"bFilter": true,
 				"bSort": true,
+				"bSortMulti": true,
 				"bInfo": true,
 				"bAutoWidth": true,
 				"bProcessing": false,
@@ -4733,7 +4734,7 @@
 					var iColumn, iNextSort;
 					
 					/* If the shift key is pressed then we are multipe column sorting */
-					if ( e.shiftKey )
+					if ( e.shiftKey && oSettings.oFeatures.bSortMulti )
 					{
 						/* Are we already doing some kind of sort on this column? */
 						var bFound = false;
@@ -6952,6 +6953,7 @@
 				_fnMap( oSettings.oFeatures, oInit, "bLengthChange" );
 				_fnMap( oSettings.oFeatures, oInit, "bFilter" );
 				_fnMap( oSettings.oFeatures, oInit, "bSort" );
+				_fnMap( oSettings.oFeatures, oInit, "bSortMulti");
 				_fnMap( oSettings.oFeatures, oInit, "bInfo" );
 				_fnMap( oSettings.oFeatures, oInit, "bProcessing" );
 				_fnMap( oSettings.oFeatures, oInit, "bAutoWidth" );


### PR DESCRIPTION
Added a <code>bSortMulti</code> feature option. When set to <code>false</code>, pressing the shift key to sort multiple columns at once will be disabled. This is handy when simplifying the logic for dealing with server-side sorting. Based on [this forum discussion](http://datatables.net/forums/discussion/5589/possible-to-disable-sorting-of-multiple-columns#Item_2).
