### PR TITLE
Extra undefined verification during _fnDrawHead

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -3157,6 +3157,7 @@
 
 						/* Expand the cell to cover as many rows as needed */
 						while ( typeof aoLocal[i+iRowspan] != 'undefined' &&
+                                                        typeof aoLocal[i+iRowspan][j] != 'undefined' &&
 						        aoLocal[i][j].cell == aoLocal[i+iRowspan][j].cell )
 						{
 							aApplied[i+iRowspan][j] = 1;


### PR DESCRIPTION
I had a table with a lot of <th> and after 1.8+ it started to throw undefined errors because of an extra verification missing.
