### PR TITLE
Added support for using the mDataProp attribute for setting aoColumnDefs and aaSorting values.

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -7365,7 +7365,6 @@
 						}
 					}
 				}
-
 				
 				var oColumn = oSettings.aoColumns[ oSettings.aaSorting[i][0] ];
 				


### PR DESCRIPTION
This patch allows the user to use the same string value supplied for the mDataProp value from aoColumns when the user is setting aoColumnDefs with aTargets, or setting column sorting.

This allows the user to modify the table (change the order of columns, add new columns in the middle, etc.) without having to reset all the aTargets and aaSorting values based on new indexes.
