### PR TITLE
Add oLanguage option to specify full Search HTML.

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -4273,14 +4273,21 @@
 		 */
 		function _fnFeatureHtmlFilter ( oSettings )
 		{
-			var sSearchStr = oSettings.oLanguage.sSearch;
-			sSearchStr = (sSearchStr.indexOf('_INPUT_') !== -1) ?
-			  sSearchStr.replace('_INPUT_', '<input type="text" />') :
-			  sSearchStr==="" ? '<input type="text" />' : sSearchStr+' <input type="text" />';
-			
 			var nFilter = document.createElement( 'div' );
 			nFilter.className = oSettings.oClasses.sFilter;
-			nFilter.innerHTML = '<label>'+sSearchStr+'</label>';
+			var sSearchHTML = oSettings.oLanguage.sSearchHtml;
+
+			if ( typeof sSearchHTML == 'undefined' )
+			{
+				var sSearchStr = oSettings.oLanguage.sSearch;
+				sSearchStr = (sSearchStr.indexOf('_INPUT_') !== -1) ?
+			  	  sSearchStr.replace('_INPUT_', '<input type="text" />') :
+			  	  sSearchStr==="" ? '<input type="text" />' : sSearchStr+' <input type="text" />';
+				sSearchHTML =  '<label>'+sSearchStr+'</label>';
+			}
+
+			nFilter.innerHTML = sSearchHTML;
+
 			if ( oSettings.sTableId !== '' && typeof oSettings.aanFeatures.f == "undefined" )
 			{
 				nFilter.setAttribute( 'id', oSettings.sTableId+'_filter' );


### PR DESCRIPTION
I didn't want the <input> to be wrapped inside the <label> so I added a new option to oLanguage, sSearchHtml, which is used as-is instead of generating with sSearch.
