### PR TITLE
Apply some DRY to pagination extension code

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -286,6 +286,13 @@
 			 */
 			"fnInit": function ( oSettings, nPaging, fnCallbackDraw )
 			{
+				function fnClickHandler ( e ) {
+					if ( oSettings.oApi._fnPageChange( oSettings, e.data.action ) )
+					{
+						fnCallbackDraw( oSettings );
+					}
+				}
+				
 				var nPrevious, nNext, nPreviousInner, nNextInner;
 				
 				/* Store the next and previous elements in the oSettings object as they can be very
@@ -319,24 +326,12 @@
 				nPaging.appendChild( nPrevious );
 				nPaging.appendChild( nNext );
 				
-				$(nPrevious).bind( 'click.DT', function() {
-					if ( oSettings.oApi._fnPageChange( oSettings, "previous" ) )
-					{
-						/* Only draw when the page has actually changed */
-						fnCallbackDraw( oSettings );
-					}
-				} );
-				
-				$(nNext).bind( 'click.DT', function() {
-					if ( oSettings.oApi._fnPageChange( oSettings, "next" ) )
-					{
-						fnCallbackDraw( oSettings );
-					}
-				} );
-				
-				/* Take the brutal approach to cancelling text selection */
-				$(nPrevious).bind( 'selectstart.DT', function () { return false; } );
-				$(nNext).bind( 'selectstart.DT', function () { return false; } );
+				$(nPrevious)
+					.bind( 'click.DT', { action: "previous" }, fnClickHandler )
+					.bind( 'selectstart.DT', function () { return false; } ); /* Take the brutal approach to cancelling text selection */
+				$(nNext)
+					.bind( 'click.DT', { action: "next" }, fnClickHandler )
+					.bind( 'selectstart.DT', function () { return false; } ); /* Take the brutal approach to cancelling text selection */
 				
 				/* ID the first elements only */
 				if ( oSettings.sTableId !== '' && typeof oSettings.aanFeatures.p == "undefined" )


### PR DESCRIPTION
The bound events for the first, previous, next, and last events are exactly the same minus the action that the _fnPageChange function should take. Parameterize this argument using the jQuery bind eventData parameter. Saves bytes and is more DRY :)
