### PR TITLE
default values in fnRender + updating cells with object

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -1953,7 +1953,7 @@
 					sDisplay = oSettings.aoColumns[iColumn].fnRender( {
 						"iDataRow": iRow,
 						"iDataColumn": iColumn,
-						"aData": oSettings.aoData[iRow]._aData,
+						"aData": _fnApplyColumnsDefault(oSettings, oSettings.aoData[iRow]._aData),
 						"oSettings": oSettings
 					} );
 					
@@ -2488,6 +2488,21 @@
 		}
 		
 		/*
+		 * Function: _fnApplyColumnsDefault
+		 * Purpose:  Returns given data with applied default values from columns.
+		 * Returns:  object
+		 * Inputs:   object:oSettings - dataTables settings object
+		 *           object:aData - row data
+		 */
+		function _fnApplyColumnsDefault(oSettings, aData){
+			var defaults={};
+			jQuery.each(oSettings.aoColumns, function(index,column){
+				defaults[column.mDataProp?column.mDataProp:index] = column.sDefaultContent;
+			});
+			return jQuery.extend(defaults, aData);
+		}
+		
+		/*
 		 * Function: _fnAddColumn
 		 * Purpose:  Add a column to the list used for the table with default values
 		 * Returns:  -
@@ -2669,7 +2684,7 @@
 					_fnSetCellData( oSettings, iRow, i, oCol.fnRender( {
 						"iDataRow": iRow,
 						"iDataColumn": i,
-						"aData": oData._aData,
+						"aData": _fnApplyColumnsDefault(oSettings, oData._aData),
 						"oSettings": oSettings
 					} ) );
 				}
@@ -2748,7 +2763,7 @@
 						nTd.innerHTML = oCol.fnRender( {
 							"iDataRow": iRow,
 							"iDataColumn": i,
-							"aData": oData._aData,
+							"aData": _fnApplyColumnsDefault(oSettings, oData._aData),
 							"oSettings": oSettings
 						} );
 					}
@@ -6814,6 +6829,7 @@
 		this.oApi._fnInitComplete = _fnInitComplete;
 		this.oApi._fnLanguageProcess = _fnLanguageProcess;
 		this.oApi._fnAddColumn = _fnAddColumn;
+		this.oApi._fnApplyColumnsDefault = _fnApplyColumnsDefault;
 		this.oApi._fnColumnOptions = _fnColumnOptions;
 		this.oApi._fnAddData = _fnAddData;
 		this.oApi._fnCreateTr = _fnCreateTr;


### PR DESCRIPTION
commit 2d12ad83e13bf69bf6991ecda193b93277cb6787
You can set object as default/normal value for cell and then render it with fnRender but default values from aoColumns are not applied. My patch does not resolve this problem when using aoColumnDefs... in case there is another way to do this

commit 670f56542699632033e95405c321e17d4a806348
In the same example, when fnUpdate is called for one cell to set object as its value, it will run code targeted for updating row (and that in my case will crash firefox8 :) )
You can use fnGetData and then update original object but it will not trigger table refresh/update.
This patch is simple but changes API.
