### PR TITLE
When fnUpdate is called, fnReDraw fires before every columns fnRender

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -1921,33 +1921,9 @@
 			var iVisibleColumn, i, iLen, sDisplay;
 			var iRow = (typeof mRow == 'object') ? 
 				_fnNodeToDataIndex(oSettings, mRow) : mRow;
-			
-			if ( $.isArray(mData) && typeof mData == 'object' )
-			{
-				/* Array update - update the whole row */
-				oSettings.aoData[iRow]._aData = mData.slice();
 
-				for ( i=0 ; i<oSettings.aoColumns.length ; i++ )
-				{
-					this.fnUpdate( _fnGetCellData( oSettings, iRow, i ), iRow, i, false, false );
-				}
-			}
-			else if ( mData !== null && typeof mData == 'object' )
+			function _fnUpdateIndividualCell()
 			{
-				/* Object update - update the whole row - assume the developer gets the object right */
-				oSettings.aoData[iRow]._aData = $.extend( true, {}, mData );
-
-				for ( i=0 ; i<oSettings.aoColumns.length ; i++ )
-				{
-					this.fnUpdate( _fnGetCellData( oSettings, iRow, i ), iRow, i, false, false );
-				}
-			}
-			else
-			{
-				/* Individual cell update */
-				sDisplay = mData;
-				_fnSetCellData( oSettings, iRow, iColumn, sDisplay );
-				
 				if ( oSettings.aoColumns[iColumn].fnRender !== null )
 				{
 					sDisplay = oSettings.aoColumns[iColumn].fnRender( {
@@ -1968,6 +1944,39 @@
 					/* Do the actual HTML update */
 					_fnGetTdNodes( oSettings, iRow )[iColumn].innerHTML = sDisplay;
 				}
+			}
+			
+			if ( $.isArray(mData) && typeof mData == 'object' )
+			{
+				/* Array update - update the whole row */
+				oSettings.aoData[iRow]._aData = mData.slice();
+
+				for ( i=0 ; i<oSettings.aoColumns.length ; i++ )
+				{
+					sDisplay = mData[i];
+					iColumn = i;
+					_fnUpdateIndividualCell();
+				}
+			}
+			else if ( mData !== null && typeof mData == 'object' )
+			{
+				/* Object update - update the whole row - assume the developer gets the object right */
+				oSettings.aoData[iRow]._aData = $.extend( true, {}, mData );
+
+				for ( i=0 ; i<oSettings.aoColumns.length ; i++ )
+				{
+					sDisplay = mData[oSettings.aoColumns[i].mDataProp];
+					iColumn = i;
+					_fnUpdateIndividualCell();
+				}
+			}
+			else
+			{
+				/* Individual cell update */
+				sDisplay = mData;
+				_fnSetCellData( oSettings, iRow, iColumn, sDisplay );
+				
+				_fnUpdateIndividualCell();
 			}
 			
 			/* Modify the search index for this row (strictly this is likely not needed, since fnReDraw


### PR DESCRIPTION
When updating an entire row with data based on a data structure with nested objects or arrays, `fnReDraw` will die with a `TypeError`, leaving the raw data in `aData` and causing further calls to `fnReDraw` to fail.

For example, in my case I am building a datatable from a JSON data structure from a service.  My data looks like this:

```
[
  {
    "id": 000000,
    "cars": [ "pontiac firebird", "toyota supra" ]
  },
...
]
```

And lets say, I specify an `fnRender` function for the `cars` column:

```
"fnRender": function(oObj){
  var ret = "<ul>";
  for( var i in oObj.aData.cars ){
    ret += "<li>" + oObj.aData.cars[i] + "</li>";
  }
  return ret + "</ul>";
}
```

Calling `fnUpdate` as it is now will die silently.  Internally there will be a `TypeError` when a `.replace` is called on the `cars` element.  See:  https://github.com/DataTables/DataTables/blob/master/media/src/core/core.filter.js#L370

My changes cause the entire row to be rendered ( if updating a whole row ) before the search string update and `fnReDraw` calls.

EDIT - Updated the link to the offending line in the `src` dir.
