### PR TITLE
fnAddData ignoring default value of bRedraw parameter

### DIFF
--- a/media/src/api/api.methods.js
+++ b/media/src/api/api.methods.js
@@ -181,7 +181,7 @@ this.fnAddData = function( mData, bRedraw )
 	
 	oSettings.aiDisplay = oSettings.aiDisplayMaster.slice();
 	
-	if ( bRedraw )
+	if ( bRedraw === undefined || bRedraw )
 	{
 		_fnReDraw( oSettings );
 	}


### PR DESCRIPTION
Today I discovered that fnAddData by default does not redraw the table. 
Here is a single line fix to that bug. And I do believe it is a bug ;)

Signed-off-by: Michal Poreba michalporeba@gmail.com
