### PR TITLE
Added 'oData._aData.DT_RowData' to set <tr> HTML5 'data-*' custom attributes

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -994,7 +994,12 @@
 				{
 					$(oData.nTr).addClass( oData._aData.DT_RowClass );
 				}
-		
+				
+				if ( oData._aData.DT_RowData )
+				{
+					$(oData.nTr).data( oData._aData.DT_RowData );
+				}
+				
 				/* Process each column */
 				for ( var i=0, iLen=oSettings.aoColumns.length ; i<iLen ; i++ )
 				{


### PR DESCRIPTION
A more generic way to set non-data properties could be jQuery's `$(<tr>).prop(oData)` function.
