### PR TITLE
Fix calculation of column width when header cell is empty

### DIFF
--- a/media/src/core/core.sizing.js
+++ b/media/src/core/core.sizing.js
@@ -77,7 +77,7 @@ function _fnCalculateColumnWidths ( oSettings )
 	{
 		for ( i=0 ; i<oSettings.aoColumns.length ; i++ )
 		{
-			iTmpWidth = $(oHeaders[i]).width();
+			iTmpWidth = $(oHeaders[i]).outerWidth();
 			if ( iTmpWidth !== null )
 			{
 				oSettings.aoColumns[i].sWidth = _fnStringToCss( iTmpWidth );


### PR DESCRIPTION
If a header cell in a table is empty its width is not calculated, causing it to get "auto" for its width. This patch fixes that.

Information on this problem can be found at http://eden.sahanafoundation.org/ticket/1081
