### PR TITLE
Remove cruft from fnSetColumnVis and fnUpdate

### DIFF
--- a/media/src/api/api.methods.js
+++ b/media/src/api/api.methods.js
@@ -1164,7 +1164,7 @@ this.fnSortListener = function( nNode, iColumn, fnCallback )
 this.fnUpdate = function( mData, mRow, iColumn, bRedraw, bAction )
 {
 	var oSettings = _fnSettingsFromNode( this[DataTable.ext.iApiIndex] );
-	var iVisibleColumn, i, iLen, sDisplay;
+	var i, iLen, sDisplay;
 	var iRow = (typeof mRow === 'object') ? 
 		_fnNodeToDataIndex(oSettings, mRow) : mRow;
 	


### PR DESCRIPTION
These two functions have a couple of unused variables. They most likely get removed during minification and don't cause any harm really, but they do make the code harder to understand when they are there.
