### PR TITLE
If any rows change state, when the dataTable is destroyed and re-created the row is added

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -5267,15 +5267,7 @@
 			else if ( !bRemove )
 			{
 				nOrig.appendChild( oSettings.nTable );
-			}
-		
-			for ( i=0, iLen=oSettings.aoData.length ; i<iLen ; i++ )
-			{
-				if ( oSettings.aoData[i].nTr !== null )
-				{
-					nBody.appendChild( oSettings.aoData[i].nTr );
-				}
-			}
+			}		
 			
 			/* Restore the width of the original table */
 			if ( oSettings.oFeatures.bAutoWidth === true )


### PR DESCRIPTION
If you look at rows 5272, even though the table is put back to its original state, the cache rows seem to be added again.  If for some reason one of the rows before the destroy call has its state or data changed, it isn't seen in the cached list and is therefore added again.

Can anyone check this behaviour?

Steps:

1) bind dataTable to normal HTML table
2) change the row somehow (I used knockoutJS with the rows as observables) to change 1 row
3) destroyed the table
4) re-bound the table to a sub-set of data (again using KnockoutJS)
5) re-bind the table again using the existing instance of the dataTable
6) the changed row is included in the filtered subset even though it doesn't appear in the data.
