### PR TITLE
Pagination plug-in : no_total

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -2413,6 +2413,10 @@
 				/* Normal record set */
 				sOut = oLang.sInfo;
 			}
+            else if (isNaN(iTotal))
+            {
+                sOut = oLang.sInfoUnknown;
+            }
 			else
 			{
 				/* Record set after filtering */
@@ -2826,7 +2830,7 @@
 				if ( oSettings._iDisplayLength >= 0 )
 				{
 					/* Make sure we are not over running the display array */
-					if ( oSettings._iDisplayStart + oSettings._iDisplayLength < oSettings.fnRecordsDisplay() )
+					if ( isNaN(oSettings.fnRecordsDisplay()) || oSettings._iDisplayStart + oSettings._iDisplayLength < oSettings.fnRecordsDisplay() )
 					{
 						oSettings._iDisplayStart += oSettings._iDisplayLength;
 					}
@@ -9076,7 +9080,23 @@
 			 *    } );
 			 */
 			"sInfo": "Showing _START_ to _END_ of _TOTAL_ entries",
-		
+	
+			/**
+			 * Same as sInfo, but used when no information about the total number of records has been given.
+			 *  @type string
+			 *  @default Showing _START_ to _END_ of more entries _TOTAL_ entries
+			 *  @dtopt Language
+			 * 
+			 *  @example
+			 *    $(document).ready(function() {
+			 *      $('#example').dataTable( {
+			 *        "oLanguage": {
+			 *          "sInfoUnknown": "A  (_START_ to _END_) subarray of an unknown number of entries"
+			 *        }
+			 *      } );
+			 *    } );
+             */
+            "sInfoUnknown" : "Showing _START_ to _END_ of more entries",
 		
 			/**
 			 * Display information string for when the table is empty. Typically the 
@@ -11125,7 +11145,9 @@
 			if ( this.oFeatures.bServerSide ) {
 				if ( this.oFeatures.bPaginate === false || this._iDisplayLength == -1 ) {
 					return this._iDisplayStart+this.aiDisplay.length;
-				} else {
+				} else if ( isNaN(this._iRecordsDisplay)) {
+		            return this._iDisplayStart+this._iDisplayLength;
+                } else {
 					return Math.min( this._iDisplayStart+this._iDisplayLength, 
 						this._iRecordsDisplay );
 				}
@@ -11540,9 +11562,8 @@
 					);
 				}
 			}
-		}
-	} );
-	
+		}});
+
 	$.extend( DataTable.ext.oSort, {
 		/*
 		 * text sorting

--- a/media/js/pagination_no_total_plug_in.js
+++ b/media/js/pagination_no_total_plug_in.js
@@ -1,0 +1,97 @@
+
+
+jQuery.fn.dataTableExt.oPagination.no_total = 
+    {
+		/*
+         * Variable: no_total
+         * Purpose:  Pagination with first/previous/next buttons without previous knowledge of the total number of entries
+         * Scope:    jQuery.fn.dataTableExt
+         */
+		"fnInit": function ( oSettings, nPaging, fnCallbackDraw )
+		{
+
+			nFirst = document.createElement( 'span' );
+			nPrevious = document.createElement( 'span' );
+			nNext = document.createElement( 'span' );
+
+			cl = oSettings.oClasses;
+
+			nFirst.appendChild( document.createTextNode( oSettings.oLanguage.oPaginate.sFirst ) );
+			nPrevious.appendChild( document.createTextNode( oSettings.oLanguage.oPaginate.sPrevious ) );
+			nNext.appendChild( document.createTextNode( oSettings.oLanguage.oPaginate.sNext ) );
+			
+			nFirst.className = cl.sPageButton + " " + cl.sPageFirst;
+			nPrevious.className = cl.sPageButton + " "+ cl.sPagePrevious;
+			nNext.className= cl.sPageButton + " " +  cl.sPageNext;
+			
+			nPaging.appendChild( nFirst );
+			nPaging.appendChild( nPrevious );
+			nPaging.appendChild( nNext );
+			
+			$(nFirst).click( function () {
+				if($(this).hasClass(cl.sPageButtonActive))
+				{
+					oSettings.oApi._fnPageChange( oSettings, "first" );
+					fnCallbackDraw( oSettings );
+				}
+			});
+			
+			$(nPrevious).click( function() {
+				if($(this).hasClass(cl.sPageButtonActive))
+				{
+					oSettings.oApi._fnPageChange( oSettings, "previous" );
+					fnCallbackDraw( oSettings );
+				}
+			} );
+			
+			$(nNext).click( function() {
+				if($(this).hasClass(cl.sPageButtonActive))
+				{
+					oSettings.oApi._fnPageChange( oSettings, "next" );
+					fnCallbackDraw( oSettings );
+				}
+			} );
+			
+			/* Disallow text selection */
+			$(nFirst).bind( 'selectstart', function () { return false; } );
+			$(nPrevious).bind( 'selectstart', function () { return false; } );
+			$(nNext).bind( 'selectstart', function () { return false; } );
+		},
+		
+		
+	    "fnUpdate": function ( oSettings, fnCallbackDraw )
+	    {
+			if ( !oSettings.aanFeatures.p )
+			{
+				return;
+			}
+			
+			oClasses = oSettings.oClasses;
+
+			/* Loop over each instance of the pager */
+			var an = oSettings.aanFeatures.p;
+			for ( var i=0, iLen=an.length ; i<iLen ; i++ )
+			{
+				var buttons = an[i].getElementsByTagName('span');
+				if ( oSettings._iDisplayStart === 0 )
+				{
+					buttons[0].className = oClasses.sPageButtonStaticDisabled + " " + oClasses.sPageFirst;
+					buttons[1].className = oClasses.sPageButtonStaticDisabled + " " + oClasses.sPagePrevious;	
+				}
+				else
+				{
+					buttons[0].className = oClasses.sPageButton + " " + oClasses.sPageButtonActive + " " + oClasses.sPageFirst;
+					buttons[1].className = oClasses.sPageButton + " " + oClasses.sPageButtonActive + " " + oClasses.sPagePrevious;
+				}
+				
+				if ( isNaN(oSettings.fnRecordsDisplay()) || !(oSettings.fnDisplayEnd() == oSettings.fnRecordsDisplay()))
+				{
+					buttons[2].className = oClasses.sPageButton + " " + oClasses.sPageButtonActive + " " + oClasses.sPageNext
+				}
+				else
+				{
+					buttons[2].className = oClasses.sPageButtonStaticDisabled + " " + oClasses.sPageNext;
+				}
+			}
+		}
+    }


### PR DESCRIPTION
no_total pagination plug-in can be used to display data even when the total number of records is unknown.

Display three buttons : first, previous, and next.
Next is clickable as long as iTotalRecords has not been sent.
