### PR TITLE
fnScrollDrawCallback

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -3363,6 +3363,9 @@
 			{
 				nScrollBody.scrollTop = 0;
 			}
+			
+			/* Fire off the scroll draw callbacks for plug-ins etc */
+			_fnCallbackFire( o, "aoScrollDrawCallback", "scrollDraw", [oSettings] );
 		}
 		
 		
@@ -6307,6 +6310,7 @@
 			_fnCallbackReg( oSettings, 'aoFooterCallback',     oInit.fnFooterCallback,    'user' );
 			_fnCallbackReg( oSettings, 'aoInitComplete',       oInit.fnInitComplete,      'user' );
 			_fnCallbackReg( oSettings, 'aoPreDrawCallback',    oInit.fnPreDrawCallback,   'user' );
+			_fnCallbackReg( oSettings, 'aoScrollDrawCallback', oInit.fnScrollDrawCallback,'user' );
 			
 			if ( oSettings.oFeatures.bServerSide && oSettings.oFeatures.bSort &&
 				   oSettings.oFeatures.bSortClasses )
@@ -8466,6 +8470,27 @@
 		 *    } );
 		 */
 		"fnPreDrawCallback": null,
+	
+	
+		/**
+		 * Called at the very end of each scroll draw.  This can be used to recalculate custom
+		 * dom elements if the scroll is adjusted without a full redraw.
+		 *  @type function
+		 *  @param {object} oSettings DataTables settings object
+		 *  @dtopt Callbacks
+		 * 
+		 *  @example
+		 *    $(document).ready( function() {
+		 *      $('#example').dataTable( {
+		 *        "fnScrollDrawCallback": function( oSettings ) {
+		 *          if ( $('#test').val() == 1 ) {
+		 *            return false;
+		 *          }
+		 *        }
+		 *      } );
+		 *    } );
+		 */
+		"fnScrollDrawCallback": null,
 	
 	
 		/**
@@ -10702,6 +10727,13 @@
 		 *  @default []
 		 */
 		"aoPreDrawCallback": [],
+		
+		/**
+		 * Callback functions for just after the scroll is drawn.
+		 *  @type array
+		 *  @default []
+		 */
+		"aoScrollDrawCallback": [],
 		
 		/**
 		 * Callback functions for when the table has been initialised.


### PR DESCRIPTION
The new ColVis feature that supresses the AJAX callback when a column state is changed is great but it broke a plugin a have that has to be resized everytime the table width changes.  This adds a new callback (fnScrollDrawCallback) and event (scrollDraw) which will be called at the end of fnScrollDraw.
