### PR TITLE
Fix typos in examples/api/multi_filter_select.html

### DIFF
--- a/examples/api/multi_filter_select.html
+++ b/examples/api/multi_filter_select.html
@@ -28,13 +28,13 @@
 				// check that we have a column id
 				if ( typeof iColumn == "undefined" ) return new Array();
 				
-				// by default we only wany unique data
+				// by default we only want unique data
 				if ( typeof bUnique == "undefined" ) bUnique = true;
 				
 				// by default we do want to only look at filtered data
 				if ( typeof bFiltered == "undefined" ) bFiltered = true;
 				
-				// by default we do not wany to include empty values
+				// by default we do not want to include empty values
 				if ( typeof bIgnoreEmpty == "undefined" ) bIgnoreEmpty = true;
 				
 				// list of rows which we're going to loop through
@@ -554,13 +554,13 @@ $.fn.dataTableExt.oApi.fnGetColumnData = function ( oSettings, iColumn, bUnique,
 	// check that we have a column id
 	if ( typeof iColumn == "undefined" ) return new Array();
 	
-	// by default we only wany unique data
+	// by default we only want unique data
 	if ( typeof bUnique == "undefined" ) bUnique = true;
 	
 	// by default we do want to only look at filtered data
 	if ( typeof bFiltered == "undefined" ) bFiltered = true;
 	
-	// by default we do not wany to include empty values
+	// by default we do not want to include empty values
 	if ( typeof bIgnoreEmpty == "undefined" ) bIgnoreEmpty = true;
 	
 	// list of rows which we're going to loop through


### PR DESCRIPTION
a few instances of 'wany' which I assumed are meant to be 'want'
