### PR TITLE
Added a check for null to the fnGetData function on the mRow variable.

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -5634,32 +5634,37 @@
 		this.fnGetData = function( mRow, iCol )
 		{
 			var oSettings = _fnSettingsFromNode( this[DataTable.ext.iApiIndex] );
-			
-			if ( mRow !== undefined )
+			if ( mRow != null )
 			{
-				var iRow = mRow;
-				if ( typeof mRow === 'object' )
-				{
-					var sNode = mRow.nodeName.toLowerCase();
-					if (sNode === "tr" )
-					{
-						iRow = _fnNodeToDataIndex(oSettings, mRow);
-					}
-					else if ( sNode === "td" )
-					{
-						iRow = _fnNodeToDataIndex(oSettings, mRow.parentNode);
-						iCol = _fnNodeToColumnIndex( oSettings, iRow, mRow );
-					}
-				}
+			  if ( mRow !== undefined )
+			  {
+				  var iRow = mRow;
+				  if ( typeof mRow === 'object' )
+				  {
+					  var sNode = mRow.nodeName.toLowerCase();
+					  if (sNode === "tr" )
+					  {
+						  iRow = _fnNodeToDataIndex(oSettings, mRow);
+					  }
+					  else if ( sNode === "td" )
+					  {
+						  iRow = _fnNodeToDataIndex(oSettings, mRow.parentNode);
+						  iCol = _fnNodeToColumnIndex( oSettings, iRow, mRow );
+					  }
+				  }
 		
-				if ( iCol !== undefined )
-				{
-					return _fnGetCellData( oSettings, iRow, iCol, '' );
-				}
-				return (oSettings.aoData[iRow]!==undefined) ?
-					oSettings.aoData[iRow]._aData : null;
-			}
-			return _fnGetDataMaster( oSettings );
+				  if ( iCol !== undefined )
+				  {
+					  return _fnGetCellData( oSettings, iRow, iCol, '' );
+				  }
+				  return (oSettings.aoData[iRow]!==undefined) ?
+					  oSettings.aoData[iRow]._aData : null;
+			  }
+			  return _fnGetDataMaster( oSettings );
+		  }
+		  else {
+		    return false;
+		  }
 		};
 		
 		


### PR DESCRIPTION
We are getting an exception from dataTables after upgrading to 1.9.2, it was because mRow was null when there was no data on the table. By adding the check for null, the exception seized.

I'm submitting this change for your consideration, so in the future our company can upgrade without missing this code from our copy of dataTables and to solve it for whomever may encounter the same issue.

Kindest regards and thanks for an amazing plugin.
