### PR TITLE
Don't redraw a filter element if the user is currently manipulating it

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -5577,7 +5577,9 @@
 					var n = oSettings.aanFeatures.f;
 					for ( var i=0, iLen=n.length ; i<iLen ; i++ )
 					{
-						$(n[i]._DT_Input).val( sInput );
+						if ( n[i]._DT_Input != document.activeElement ) {
+							$(n[i]._DT_Input).val( sInput );
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This is a fix for an issue I actually ran into while using the dataTables.filteringDelay plugin.

I was able to cause the original issue in Firefox 13.0.1 on Mac OS X (may happen on other OSes.) Could not reproduce in Chrome 20.0.1132.47 on Mac OS X.

When using the filteringDelay plugin and typing a filter term longer than the width of the filter input, the text position inside the input box isreset all the way to the left after each delay period, which could be jarring to the user if they type slowly ("Why can't I see my cursor anymore?")

This simple tweak prevents the currently-focused input element from getting overwritten, which fixes the behavior described above.
