### PR TITLE
Fix: fnUpdate incorrectly updates the entire row if a Date object is passed as the first arg

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -6100,7 +6100,7 @@
 					this.fnUpdate( _fnGetCellData( oSettings, iRow, i ), iRow, i, false, false );
 				}
 			}
-			else if ( $.isPlainObject(mData) && iColumn === undefined )
+			else if ( $.isPlainObject(mData) && iColumn === undefined && !(mData instanceof Date))
 			{
 				/* Object update - update the whole row - assume the developer gets the object right */
 				oSettings.aoData[iRow]._aData = $.extend( true, {}, mData );


### PR DESCRIPTION
How to reproduce:

dataTable.fnUpdate(new Date(), 0, 0);

The solution is checking whether mData is instanceof Date before deciding its a row update.
