### PR TITLE
check for oData !== undefined before oData.Tr !== null

### DIFF
--- a/media/src/core/core.support.js
+++ b/media/src/core/core.support.js
@@ -67,7 +67,7 @@ function _fnGetTdNodes ( oSettings, iIndividualRow )
 	for ( iRow=iStart ; iRow<iEnd ; iRow++ )
 	{
 		oData = oSettings.aoData[iRow];
-		if ( oData.nTr !== null )
+		if ( oData !== undefined && oData.nTr !== null )        
 		{
 			/* get the TD child nodes - taking into account text etc nodes */
 			anTds = [];


### PR DESCRIPTION
In instances where I'm doing a large number of concurrent fnUpdate() calls, oData would sometime be undefined, causing the oData.nTr !== null check to fail. Adding a check for oData !== undefined helps move things along.
