### PR TITLE
Memory leak fixes

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -5387,7 +5387,6 @@
 			
 			/* Blitz all DT events */
 			$(oSettings.nTableWrapper).find('*').andSelf().unbind('.DT');
-			$('thead>tr>th', oSettings.nTable).unbind('.DT');
 			
 			/* If there is an 'empty' indicator row, remove it */
 			$('tbody>tr>td.'+oSettings.oClasses.sRowEmpty, oSettings.nTable).parent().remove();


### PR DESCRIPTION
I added two fixes for memory leaks that I discovered using Google Chrome's heap snapshot tool: one for sort event handlers that were not unbound and one for a jQuery reference that was never cleared.

When testing with a data grid of 450 rows, this fix reduced the heap size by approximately 2 MB.
