### PR TITLE
Fixed memory leak

### DIFF
--- a/media/src/DataTables.js
+++ b/media/src/DataTables.js
@@ -78,9 +78,11 @@
 		require('api.internal.js');
 		
 		var _that = this;
-		return this.each(function() {
+		this.each(function() {
 			require('core.constructor.js');
 		} );
+		_that = null;
+		return this;
 	};
 
 	require('api.static.js');


### PR DESCRIPTION
I cleaned up the _that variables that was being stored for the life of the data grid even though it wasn't needed after the initialization.

This originates from pull request #80.
