### PR TITLE
Added fix for memory leak because of potential circular reference

### DIFF
--- a/media/src/api/api.methods.js
+++ b/media/src/api/api.methods.js
@@ -581,6 +581,7 @@ this.fnDestroy = function ( bRemove )
 	
 	/* End it all */
 	oSettings = null;
+	oInit = null;
 };
 
 


### PR DESCRIPTION
I made a change to resolve a memory leak that can occur because of a circular reference. Take a look at the following example:

```
        $(document).ready(function() {
            function MyDataTableWrapper() {
                var oDataTable = $('#example').dataTable({
                    "fnRowCallback":jQuery.proxy(callback, this)
                });
                oDataTable.fnDestroy();

                function callback(){}
            }

            var myWrapper = new MyDataTableWrapper();
            myWrapper = null;
        } );
```

After this code is executed, take a heap snapshot with the Google Chrome tools. You will see that a reference to the MyDataTableWrapper instance still exists in memory. This is because the browser is keeping a reference to "this" in the jQuery proxied function, which is reference by oInit, which is then being referenced by the various internal data grid functions. This prevents DataTables from being completely cleaned up after it is destroyed and removed from the DOM. This fix resolves that by marking the configuration map, oInit, for garbage collection and ending the circular reference.
