### PR TITLE
Only restore hidden columns if table is not being removed from DOM

### DIFF
--- a/media/src/api/api.methods.js
+++ b/media/src/api/api.methods.js
@@ -481,13 +481,16 @@ this.fnDestroy = function ( bRemove )
 	
 	/* Fire off the destroy callbacks for plug-ins etc */
 	_fnCallbackFire( oSettings, "aoDestroyCallback", "destroy", [oSettings] );
-	
-	/* Restore hidden columns */
-	for ( i=0, iLen=oSettings.aoColumns.length ; i<iLen ; i++ )
+
+	/* If the table is not being removed, restore the hidden columns */
+	if ( !bRemove )
 	{
-		if ( oSettings.aoColumns[i].bVisible === false )
+		for ( i=0, iLen=oSettings.aoColumns.length ; i<iLen ; i++ )
 		{
-			this.fnSetColumnVis( i, true );
+			if ( oSettings.aoColumns[i].bVisible === false )
+			{
+				this.fnSetColumnVis( i, true );
+			}
 		}
 	}
 	


### PR DESCRIPTION
When I was doing some profiling in Google Chrome, I discovered that the longest step in destroying a data grid is restoring the hidden columns. If the table is being removed from the DOM, there is no need to restore the hidden columns and the performance hit of that task can be saved.
