### PR TITLE
Update media/src/core/core.scrolling.js

### DIFF
--- a/media/src/core/core.scrolling.js
+++ b/media/src/core/core.scrolling.js
@@ -219,8 +219,8 @@ function _fnScrollDraw ( o )
 	{
 		nTfootSize = $(o.nTFoot).clone()[0];
 		o.nTable.insertBefore( nTfootSize, o.nTable.childNodes[1] );
-		anFootSizers = nTfootSize.getElementsByTagName('tr');
 		anFootToSize = o.nTFoot.getElementsByTagName('tr');
+		anFootSizers = nTfootSize.getElementsByTagName('tr');
 	}
 	
 	/*


### PR DESCRIPTION
define anHeadToSize, anHeadSizers, anFootSizers, anFootToSize earlier
use anFootSizers instead of additional call to nTfootSize.getElementsByTagName('tr')
