### PR TITLE
Update media/src/core/core.scrolling.js

### DIFF
--- a/media/src/core/core.scrolling.js
+++ b/media/src/core/core.scrolling.js
@@ -1,4 +1,3 @@
-
 /**
  * Add any control elements for the table - specifically scrolling
  *  @param {object} oSettings dataTables settings object
@@ -386,11 +385,11 @@ function _fnScrollDraw ( o )
 		
 		/* Apply the calculated minimum width to the table wrappers */
 		nScrollBody.style.width = _fnStringToCss( iCorrection );
-		nScrollHeadInner.parentNode.style.width = _fnStringToCss( iCorrection );
+		o.nScrollHead.style.width = _fnStringToCss( iCorrection );
 		
 		if ( o.nTFoot !== null )
 		{
-			nScrollFootInner.parentNode.style.width = _fnStringToCss( iCorrection );
+			o.nScrollFoot.style.width = _fnStringToCss( iCorrection );
 		}
 		
 		/* And give the user a warning that we've stopped the table getting too small */
@@ -409,11 +408,11 @@ function _fnScrollDraw ( o )
 	else
 	{
 		nScrollBody.style.width = _fnStringToCss( '100%' );
-		nScrollHeadInner.parentNode.style.width = _fnStringToCss( '100%' );
+		o.nScrollHead.style.width = _fnStringToCss( '100%' );
 		
 		if ( o.nTFoot !== null )
 		{
-			nScrollFootInner.parentNode.style.width = _fnStringToCss( '100%' );
+			o.nScrollFoot.style.width = _fnStringToCss( '100%' );
 		}
 	}
 	


### PR DESCRIPTION
Use o.nScrollHead / o.nScrollFoot rather than traversing through the dom again to get the parentNodes for nScrollHeadInner / nScroolFootInner
