### PR TITLE
Update media/src/DataTables.js

### DIFF
--- a/media/src/DataTables.js
+++ b/media/src/DataTables.js
@@ -280,5 +280,5 @@
 	 */
 }));
 
-}( window, document, undefined));
+}( window, document));
 


### PR DESCRIPTION
I noticed this trick used in jQuery itself -- they include undefined as one of the parameters to their outer closure, but they don't pass it in as a parameter.

Presumably it isn't needed, since any input parameter that doesn't get set automatically has the value of undefined.
