### PR TITLE
Fix component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,9 +1,9 @@
 {
 	"name": "DataTables",
-	"version": "1.10.0.dev",
+	"version": "1.10.0",
 	"main": [
 		"./media/js/jquery.dataTables.js",
-		"./media/css/jquery.dataTables.css",
+		"./media/css/jquery.dataTables.css"
 	],
 	"dependencies": {
 		"jquery": "~1.8.0"


### PR DESCRIPTION
Two small fixes that will prevent bower from crashing:
- use a [semver](http://semver.org/) for 'version' property
- remove syntax error in main array property
