### PR TITLE
Fix backward compatibility with mDataProp = null

### DIFF
--- a/media/src/core/core.columns.js
+++ b/media/src/core/core.columns.js
@@ -1,5 +1,4 @@
 
-
 /**
  * Add a column to the list used for the table with default values
  *  @param {object} oSettings dataTables settings object
@@ -69,7 +68,7 @@ function _fnColumnOptions( oSettings, iCol, oOptions )
 		_fnCamelToHungarian( DataTable.defaults.column, oOptions );
 		
 		/* Backwards compatibility for mDataProp */
-		if ( oOptions.mDataProp && !oOptions.mData )
+		if ( oOptions.mDataProp !== undefined && !oOptions.mData )
 		{
 			oOptions.mData = oOptions.mDataProp;
 		}


### PR DESCRIPTION
The problem is described below

http://datatables.net/forums/discussion/13077/bug-backward-compatibility-mdataprop-1.9.2-to-1.9.4
