### PR TITLE
New: Column option "bShowSortArrows"

### DIFF
--- a/media/src/core/core.columns.js
+++ b/media/src/core/core.columns.js
@@ -112,7 +112,7 @@ function _fnColumnOptions( oSettings, iCol, oOptions )
 	{
 		oCol.bSortable = false;
 	}
-	
+
 	/* Check that the class assignment is correct for sorting */
 	if ( !oCol.bSortable ||
 		 ($.inArray('asc', oCol.asSorting) == -1 && $.inArray('desc', oCol.asSorting) == -1) )

--- a/media/src/core/core.sort.js
+++ b/media/src/core/core.sort.js
@@ -400,6 +400,11 @@ function _fnSortingClasses( oSettings )
 	/* Apply the required classes to the header */
 	for ( i=0 ; i<oSettings.aoColumns.length ; i++ )
 	{
+		/* If sort arrows are disabled for this column, we're all set */
+		if ( !oSettings.aoColumns[i].bShowSortArrows ) {
+			continue;
+		}
+
 		if ( oSettings.aoColumns[i].bSortable )
 		{
 			sClass = oSettings.aoColumns[i].sSortingClass;

--- a/media/src/model/model.column.js
+++ b/media/src/model/model.column.js
@@ -46,7 +46,15 @@ DataTable.models.oColumn = {
 	 *  @type boolean
 	 */
 	"bSortable": null,
-	
+
+	/**
+	 * Flag to indicate if the column should have sort arrows. Sort arrows 
+	 * will only appear for sortable columns, so this flag has no effect if
+	 * bSortable is false.
+	 *  @type boolean
+	 */
+	"bShowSortArrows": null,
+
 	/**
 	 * Flag to indicate if the column is currently visible in the table or not
 	 *  @type boolean

--- a/media/src/model/model.defaults.columns.js
+++ b/media/src/model/model.defaults.columns.js
@@ -153,6 +153,38 @@ DataTable.defaults.column = {
 	 */
 	"bSortable": true,
 
+	/**
+	 * Show sort arrows on this column (if it is sortable).
+	 *  @type boolean
+	 *  @default true
+	 *
+	 *  @name DataTable.defaults.column.showSortArrows
+	 *  @dtopt Columns
+	 * 
+	 *  @example
+	 *    // Using `columnDefs`
+	 *    $(document).ready( function() {
+	 *      $('#example').dataTable( {
+	 *        "columnDefs": [ 
+	 *          { "showSortArrows": false, "targets": [ 0 ] }
+	 *        ] } );
+	 *    } );
+	 *    
+	 *  @example
+	 *    // Using `columns`
+	 *    $(document).ready( function() {
+	 *      $('#example').dataTable( {
+	 *        "columns": [ 
+	 *          { "showSortArrows": false },
+	 *          null,
+	 *          null,
+	 *          null,
+	 *          null
+	 *        ] } );
+	 *    } );
+	 */
+	"bShowSortArrows": true,
+
 
 	/**
 	 * Enable or disable the display of this column.


### PR DESCRIPTION
New: Column option "bShowSortArrows"

Allows you to disable sort arrows for TH tags while
still having the column be sortable.
