### PR TITLE
Update media/js/jquery.dataTables.js

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -3714,7 +3714,7 @@
 	 */
 	function _fnStringToCss( s )
 	{
-		if ( s === null )
+		if ( s === null || s === "falsepx")
 		{
 			return "0px";
 		}


### PR DESCRIPTION
Fix for ie8.
When the oSettings.oScroll.sY equals 'falsepx'. line 2998 on current revision.
Happens when the table is in div with the css attribute: 'display: none'.
