### PR TITLE
Update media/js/jquery.dataTables.js

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -3728,6 +3728,11 @@
 			return s+"px";
 		}
 		
+		if ( s === 'falsepx' )
+		{
+			return "";
+		}
+            
 		/* Check if the last character is not 0-9 */
 		var c = s.charCodeAt( s.length-1 );
 		if (c < 0x30 || c > 0x39)


### PR DESCRIPTION
Fix for ie8.
When the oSettings.oScroll.sY equals 'falsepx'. line 2998 on current revision.
Happens when the table is in div with the css attribute: 'display: none'.
