### PR TITLE
Calculate width of cell using outerWidth()

### DIFF
--- a/media/src/core/core.scrolling.js
+++ b/media/src/core/core.scrolling.js
@@ -318,7 +318,7 @@ function _fnScrollDraw ( o )
 	// Read all widths in next pass. Forces layout only once because we do not change
 	// any DOM properties.
 	_fnApplyToChildren( function(nSizer) {
-		aApplied.push( _fnStringToCss( $(nSizer).width() ) );
+		aApplied.push( _fnStringToCss( $(nSizer).outerWidth() ) );
 	}, anHeadSizers );
 
 	// Apply all widths in final pass. Invalidates layout only once because we do not


### PR DESCRIPTION
Using .width() was giving incorrect results for me on specific columns
(e.g. columns with no title and a set width). This corrects the issue.
