### PR TITLE
bugfix for oPagination.full_numbers.fnUpdate

### DIFF
--- a/media/src/ext/ext.paging.js
+++ b/media/src/ext/ext.paging.js
@@ -171,7 +171,7 @@ $.extend( DataTable.ext.oPagination, {
 			
 			var iPageCount = DataTable.ext.oPagination.iFullNumbersShowPages;
 			var iPageCountHalf = Math.floor(iPageCount / 2);
-			var iPages = Math.ceil((oSettings.fnRecordsDisplay()) / oSettings._iDisplayLength);
+			var iPages = Math.ceil((oSettings.fnRecordsTotal()) / oSettings._iDisplayLength);
 			var iCurrentPage = Math.ceil(oSettings._iDisplayStart / oSettings._iDisplayLength) + 1;
 			var sList = "";
 			var iStartButton, iEndButton, i, iLen;


### PR DESCRIPTION
Because of wrong formula "DisplayRecords/DisplayLength" the page number
was always 1 and therefore paging did not work properly.
