### PR TITLE
Allow user to extend classes object via initialisation options

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -6475,7 +6475,8 @@
 			}
 			
 			/* Allow user to extend classes object via initialisation options */
-			if ( oInit.oClasses ) {
+			if ( oInit.oClasses )
+			{
 				$.extend( oSettings.oClasses, oInit.oClasses );
 			}
 


### PR DESCRIPTION
This will allow you to do things like:

```
$('#my-table').dataTable({
    'oClasses': {
        'sWrapper': 'awesome-sauce'
    }
});
```

I feel like it makes sense to have this ability since you can already do:

```
$('#my-table').dataTable({
    'oLanguage': {
        'oPaginate': {
            'sPrevious': 'Retreat!',
            'sNext': 'Forward March!'
        }
    }
});
```

... not that you would.
