### PR TITLE
Added fnUpdatePagingInfo to DataTables.models.oSettings

### DIFF
--- a/media/src/core/core.constructor.js
+++ b/media/src/core/core.constructor.js
@@ -423,15 +423,7 @@ oSettings.aiDisplay = oSettings.aiDisplayMaster.slice();
 
 if ( oInit.bPaginate === true )
 {
-    $.extend( oSettings, {
-        '_iDisplayEnd': oSettings.fnDisplayEnd(),
-        '_iTotal': oSettings.fnRecordsTotal(),
-        '_iFilteredTotal': oSettings.fnRecordsDisplay(),
-        '_iPage': oSettings._iDisplayLength === -1 ?
-            0 : Math.ceil( ( oSettings._iDisplayStart + 1 ) / oSettings._iDisplayLength ),
-        '_iTotalPages': oSettings._iDisplayLength === -1 ?
-            0 : Math.ceil( oSettings.fnRecordsDisplay() / oSettings._iDisplayLength )
-    } );
+	oSettings.fnUpdatePagingInfo();
 }
 
 /* Initialisation complete - table can be drawn */

--- a/media/src/core/core.page.js
+++ b/media/src/core/core.page.js
@@ -17,17 +17,17 @@ function _fnFeatureHtmlPaginate ( oSettings )
 	{
 		return null;
 	}
-	
+
 	var nPaginate = document.createElement( 'div' );
 	nPaginate.className = oSettings.oClasses.sPaging+oSettings.sPaginationType;
-	
+
 	DataTable.ext.oPagination[ oSettings.sPaginationType ].fnInit( oSettings, nPaginate,
 		function( oSettings ) {
 			_fnCalculateEnd( oSettings );
 			_fnDraw( oSettings );
 		}
 	);
-	
+
 	/* Add a draw callback for the pagination on first instance, to update the paging display */
 	if ( !oSettings.aanFeatures.p )
 	{
@@ -56,7 +56,7 @@ function _fnFeatureHtmlPaginate ( oSettings )
 function _fnPageChange ( oSettings, mAction )
 {
 	var iOldStart = oSettings._iDisplayStart;
-	
+
 	if ( typeof mAction === "number" )
 	{
 		oSettings._iDisplayStart = mAction * oSettings._iDisplayLength;
@@ -74,7 +74,7 @@ function _fnPageChange ( oSettings, mAction )
 		oSettings._iDisplayStart = oSettings._iDisplayLength>=0 ?
 			oSettings._iDisplayStart - oSettings._iDisplayLength :
 			0;
-		
+
 		/* Correct for under-run */
 		if ( oSettings._iDisplayStart < 0 )
 		{
@@ -113,7 +113,9 @@ function _fnPageChange ( oSettings, mAction )
 		_fnLog( oSettings, 0, "Unknown paging action: "+mAction );
 	}
 	$(oSettings.oInstance).trigger('page', oSettings);
-	
+
+	oSettings.fnUpdatePagingInfo();
+
 	return iOldStart != oSettings._iDisplayStart;
 }
 

--- a/media/src/model/model.settings.js
+++ b/media/src/model/model.settings.js
@@ -28,7 +28,7 @@ DataTable.models.oSettings = {
 	 *  @namespace
 	 */
 	"oFeatures": {
-		
+
 		/**
 		 * Flag to say if DataTables should automatically try to calculate the
 		 * optimum table and columns widths (true) or not (false).
@@ -48,7 +48,7 @@ DataTable.models.oSettings = {
 		 *  @type boolean
 		 */
 		"bDeferRender": null,
-		
+
 		/**
 		 * Enable filtering on the table or not. Note that if this is disabled
 		 * then there is no filtering at all on the table, including fnFilter.
@@ -58,7 +58,7 @@ DataTable.models.oSettings = {
 		 *  @type boolean
 		 */
 		"bFilter": null,
-		
+
 		/**
 		 * Table information element (the 'Showing x of y records' div) enable
 		 * flag.
@@ -67,7 +67,7 @@ DataTable.models.oSettings = {
 		 *  @type boolean
 		 */
 		"bInfo": null,
-		
+
 		/**
 		 * Present a user control allowing the end user to change the page size
 		 * when pagination is enabled.
@@ -85,7 +85,7 @@ DataTable.models.oSettings = {
 		 *  @type boolean
 		 */
 		"bPaginate": null,
-		
+
 		/**
 		 * Processing indicator enable flag whenever DataTables is enacting a
 		 * user request - typically an Ajax request for server-side processing.
@@ -94,7 +94,7 @@ DataTable.models.oSettings = {
 		 *  @type boolean
 		 */
 		"bProcessing": null,
-		
+
 		/**
 		 * Server-side processing enabled flag - when enabled DataTables will
 		 * get all data from the server for every draw - there is no filtering,
@@ -104,7 +104,7 @@ DataTable.models.oSettings = {
 		 *  @type boolean
 		 */
 		"bServerSide": null,
-		
+
 		/**
 		 * Sorting enablement flag.
 		 * Note that this parameter will be set by the initialisation routine. To
@@ -112,7 +112,7 @@ DataTable.models.oSettings = {
 		 *  @type boolean
 		 */
 		"bSort": null,
-		
+
 		/**
 		 * Apply a class to the columns which are being sorted to provide a
 		 * visual highlight or not. This can slow things down when enabled since
@@ -122,7 +122,7 @@ DataTable.models.oSettings = {
 		 *  @type boolean
 		 */
 		"bSortClasses": null,
-		
+
 		/**
 		 * State saving enablement flag.
 		 * Note that this parameter will be set by the initialisation routine. To
@@ -131,7 +131,7 @@ DataTable.models.oSettings = {
 		 */
 		"bStateSave": null
 	},
-	
+
 
 	/**
 	 * Scrolling settings for a table.
@@ -147,7 +147,7 @@ DataTable.models.oSettings = {
 		 *  @type boolean
 		 */
 		"bAutoCss": null,
-		
+
 		/**
 		 * When the table is shorter in height than sScrollY, collapse the
 		 * table container down to the height of the table (when true).
@@ -156,7 +156,7 @@ DataTable.models.oSettings = {
 		 *  @type boolean
 		 */
 		"bCollapse": null,
-		
+
 		/**
 		 * Infinite scrolling enablement flag. Now deprecated in favour of
 		 * using the Scroller plug-in.
@@ -165,7 +165,7 @@ DataTable.models.oSettings = {
 		 *  @type boolean
 		 */
 		"bInfinite": null,
-		
+
 		/**
 		 * Width of the scrollbar for the web-browser's platform. Calculated
 		 * during table initialisation.
@@ -173,7 +173,7 @@ DataTable.models.oSettings = {
 		 *  @default 0
 		 */
 		"iBarWidth": 0,
-		
+
 		/**
 		 * Space (in pixels) between the bottom of the scrolling container and
 		 * the bottom of the scrolling viewport before the next page is loaded
@@ -183,7 +183,7 @@ DataTable.models.oSettings = {
 		 *  @type int
 		 */
 		"iLoadGap": null,
-		
+
 		/**
 		 * Viewport width for horizontal scrolling. Horizontal scrolling is
 		 * disabled if an empty string.
@@ -192,7 +192,7 @@ DataTable.models.oSettings = {
 		 *  @type string
 		 */
 		"sX": null,
-		
+
 		/**
 		 * Width to expand the table to when using x-scrolling. Typically you
 		 * should not need to use this.
@@ -202,7 +202,7 @@ DataTable.models.oSettings = {
 		 *  @deprecated
 		 */
 		"sXInner": null,
-		
+
 		/**
 		 * Viewport height for vertical scrolling. Vertical scrolling is disabled
 		 * if an empty string.
@@ -212,7 +212,7 @@ DataTable.models.oSettings = {
 		 */
 		"sY": null
 	},
-	
+
 	/**
 	 * Language information for the table.
 	 *  @namespace
@@ -227,7 +227,7 @@ DataTable.models.oSettings = {
 		 */
 		"fnInfoCallback": null
 	},
-	
+
 	/**
 	 * Browser support parameters
 	 *  @namespace
@@ -250,11 +250,11 @@ DataTable.models.oSettings = {
 		 */
 		"bScrollbarLeft": false
 	},
-	
+
 
 	"ajax": null,
 
-	
+
 	/**
 	 * Array referencing the nodes which are used for the features. The
 	 * parameters of this object match what is allowed by sDom - i.e.
@@ -270,7 +270,7 @@ DataTable.models.oSettings = {
 	 *  @default []
 	 */
 	"aanFeatures": [],
-	
+
 	/**
 	 * Store data information - see {@link DataTable.models.oRow} for detailed
 	 * information.
@@ -278,49 +278,49 @@ DataTable.models.oSettings = {
 	 *  @default []
 	 */
 	"aoData": [],
-	
+
 	/**
 	 * Array of indexes which are in the current display (after filtering etc)
 	 *  @type array
 	 *  @default []
 	 */
 	"aiDisplay": [],
-	
+
 	/**
 	 * Array of indexes for display - no filtering
 	 *  @type array
 	 *  @default []
 	 */
 	"aiDisplayMaster": [],
-	
+
 	/**
 	 * Store information about each column that is in use
 	 *  @type array
 	 *  @default []
 	 */
 	"aoColumns": [],
-	
+
 	/**
 	 * Store information about the table's header
 	 *  @type array
 	 *  @default []
 	 */
 	"aoHeader": [],
-	
+
 	/**
 	 * Store information about the table's footer
 	 *  @type array
 	 *  @default []
 	 */
 	"aoFooter": [],
-	
+
 	/**
 	 * Search data array for regular expression searching
 	 *  @type array
 	 *  @default []
 	 */
 	"asDataSearch": [],
-	
+
 	/**
 	 * Store the applied global search information in case we want to force a
 	 * research or compare the old search to a new one.
@@ -330,7 +330,7 @@ DataTable.models.oSettings = {
 	 *  @extends DataTable.models.oSearch
 	 */
 	"oPreviousSearch": {},
-	
+
 	/**
 	 * Store the applied search for each column - see
 	 * {@link DataTable.models.oSearch} for the format that is used for the
@@ -339,7 +339,7 @@ DataTable.models.oSettings = {
 	 *  @default []
 	 */
 	"aoPreSearchCols": [],
-	
+
 	/**
 	 * Sorting that is applied to the table. Note that the inner arrays are
 	 * used in the following manner:
@@ -354,7 +354,7 @@ DataTable.models.oSettings = {
 	 *  @todo These inner arrays should really be objects
 	 */
 	"aaSorting": null,
-	
+
 	/**
 	 * Sorting that is always applied to the table (i.e. prefixed in front of
 	 * aaSorting).
@@ -364,7 +364,7 @@ DataTable.models.oSettings = {
 	 *  @default null
 	 */
 	"aaSortingFixed": null,
-	
+
 	/**
 	 * Classes to use for the striping of a table.
 	 * Note that this parameter will be set by the initialisation routine. To
@@ -373,56 +373,56 @@ DataTable.models.oSettings = {
 	 *  @default []
 	 */
 	"asStripeClasses": null,
-	
+
 	/**
 	 * If restoring a table - we should restore its striping classes as well
 	 *  @type array
 	 *  @default []
 	 */
 	"asDestroyStripes": [],
-	
+
 	/**
 	 * If restoring a table - we should restore its width
 	 *  @type int
 	 *  @default 0
 	 */
 	"sDestroyWidth": 0,
-	
+
 	/**
 	 * Callback functions array for every time a row is inserted (i.e. on a draw).
 	 *  @type array
 	 *  @default []
 	 */
 	"aoRowCallback": [],
-	
+
 	/**
 	 * Callback functions for the header on each draw.
 	 *  @type array
 	 *  @default []
 	 */
 	"aoHeaderCallback": [],
-	
+
 	/**
 	 * Callback function for the footer on each draw.
 	 *  @type array
 	 *  @default []
 	 */
 	"aoFooterCallback": [],
-	
+
 	/**
 	 * Array of callback functions for draw callback functions
 	 *  @type array
 	 *  @default []
 	 */
 	"aoDrawCallback": [],
-	
+
 	/**
 	 * Array of callback functions for row created function
 	 *  @type array
 	 *  @default []
 	 */
 	"aoRowCreatedCallback": [],
-	
+
 	/**
 	 * Callback functions for just before the table is redrawn. A return of
 	 * false will be used to cancel the draw.
@@ -430,7 +430,7 @@ DataTable.models.oSettings = {
 	 *  @default []
 	 */
 	"aoPreDrawCallback": [],
-	
+
 	/**
 	 * Callback functions for when the table has been initialised.
 	 *  @type array
@@ -438,7 +438,7 @@ DataTable.models.oSettings = {
 	 */
 	"aoInitComplete": [],
 
-	
+
 	/**
 	 * Callbacks for modifying the settings to be stored for state saving, prior to
 	 * saving state.
@@ -446,7 +446,7 @@ DataTable.models.oSettings = {
 	 *  @default []
 	 */
 	"aoStateSaveParams": [],
-	
+
 	/**
 	 * Callbacks for modifying the settings that have been stored for state saving
 	 * prior to using the stored values to restore the state.
@@ -454,7 +454,7 @@ DataTable.models.oSettings = {
 	 *  @default []
 	 */
 	"aoStateLoadParams": [],
-	
+
 	/**
 	 * Callbacks for operating on the settings object once the saved state has been
 	 * loaded
@@ -462,49 +462,49 @@ DataTable.models.oSettings = {
 	 *  @default []
 	 */
 	"aoStateLoaded": [],
-	
+
 	/**
 	 * Cache the table ID for quick access
 	 *  @type string
 	 *  @default <i>Empty string</i>
 	 */
 	"sTableId": "",
-	
+
 	/**
 	 * The TABLE node for the main table
 	 *  @type node
 	 *  @default null
 	 */
 	"nTable": null,
-	
+
 	/**
 	 * Permanent ref to the thead element
 	 *  @type node
 	 *  @default null
 	 */
 	"nTHead": null,
-	
+
 	/**
 	 * Permanent ref to the tfoot element - if it exists
 	 *  @type node
 	 *  @default null
 	 */
 	"nTFoot": null,
-	
+
 	/**
 	 * Permanent ref to the tbody element
 	 *  @type node
 	 *  @default null
 	 */
 	"nTBody": null,
-	
+
 	/**
 	 * Cache the wrapper node (contains all DataTables controlled elements)
 	 *  @type node
 	 *  @default null
 	 */
 	"nTableWrapper": null,
-	
+
 	/**
 	 * Indicate if when using server-side processing the loading of data
 	 * should be deferred until the second draw.
@@ -514,14 +514,14 @@ DataTable.models.oSettings = {
 	 *  @default false
 	 */
 	"bDeferLoading": false,
-	
+
 	/**
 	 * Indicate if all required information has been read in
 	 *  @type boolean
 	 *  @default false
 	 */
 	"bInitialised": false,
-	
+
 	/**
 	 * Information about open rows. Each object in the array has the parameters
 	 * 'nTr' and 'nParent'
@@ -529,7 +529,7 @@ DataTable.models.oSettings = {
 	 *  @default []
 	 */
 	"aoOpenRows": [],
-	
+
 	/**
 	 * Dictate the positioning of DataTables' control elements - see
 	 * {@link DataTable.model.oInit.sDom}.
@@ -539,7 +539,7 @@ DataTable.models.oSettings = {
 	 *  @default null
 	 */
 	"sDom": null,
-	
+
 	/**
 	 * Which type of pagination should be used.
 	 * Note that this parameter will be set by the initialisation routine. To
@@ -548,7 +548,7 @@ DataTable.models.oSettings = {
 	 *  @default two_button
 	 */
 	"sPaginationType": "two_button",
-	
+
 	/**
 	 * The state duration (for `stateSave`) in seconds.
 	 * Note that this parameter will be set by the initialisation routine. To
@@ -557,7 +557,7 @@ DataTable.models.oSettings = {
 	 *  @default 0
 	 */
 	"iStateDuration": 0,
-	
+
 	/**
 	 * Array of callback functions for state saving. Each array element is an
 	 * object with the following parameters:
@@ -572,7 +572,7 @@ DataTable.models.oSettings = {
 	 *  @default []
 	 */
 	"aoStateSave": [],
-	
+
 	/**
 	 * Array of callback functions for state loading. Each array element is an
 	 * object with the following parameters:
@@ -585,14 +585,14 @@ DataTable.models.oSettings = {
 	 *  @default []
 	 */
 	"aoStateLoad": [],
-	
+
 	/**
 	 * State that was loaded. Useful for back reference
 	 *  @type object
 	 *  @default null
 	 */
 	"oLoadedState": null,
-	
+
 	/**
 	 * Source url for AJAX data for the table.
 	 * Note that this parameter will be set by the initialisation routine. To
@@ -601,7 +601,7 @@ DataTable.models.oSettings = {
 	 *  @default null
 	 */
 	"sAjaxSource": null,
-	
+
 	/**
 	 * Property from a given object from which to read the table data from. This
 	 * can be an empty string (when not server-side processing), in which case
@@ -611,14 +611,14 @@ DataTable.models.oSettings = {
 	 *  @type string
 	 */
 	"sAjaxDataProp": null,
-	
+
 	/**
 	 * Note if draw should be blocked while getting data
 	 *  @type boolean
 	 *  @default true
 	 */
 	"bAjaxDataGet": true,
-	
+
 	/**
 	 * The last jQuery XHR object that was used for server-side data gathering.
 	 * This can be used for working with the XHR information in one of the
@@ -627,7 +627,7 @@ DataTable.models.oSettings = {
 	 *  @default null
 	 */
 	"jqXHR": null,
-	
+
 	/**
 	 * Function to get the server-side data.
 	 * Note that this parameter will be set by the initialisation routine. To
@@ -635,7 +635,7 @@ DataTable.models.oSettings = {
 	 *  @type function
 	 */
 	"fnServerData": null,
-	
+
 	/**
 	 * Functions which are called prior to sending an Ajax request so extra
 	 * parameters can easily be sent to the server
@@ -643,7 +643,7 @@ DataTable.models.oSettings = {
 	 *  @default []
 	 */
 	"aoServerParams": [],
-	
+
 	/**
 	 * Send the XHR HTTP method - GET or POST (could be PUT or DELETE if
 	 * required).
@@ -652,7 +652,7 @@ DataTable.models.oSettings = {
 	 *  @type string
 	 */
 	"sServerMethod": null,
-	
+
 	/**
 	 * Format numbers for display.
 	 * Note that this parameter will be set by the initialisation routine. To
@@ -660,7 +660,7 @@ DataTable.models.oSettings = {
 	 *  @type function
 	 */
 	"fnFormatNumber": null,
-	
+
 	/**
 	 * List of options that can be used for the user selectable length menu.
 	 * Note that this parameter will be set by the initialisation routine. To
@@ -669,7 +669,7 @@ DataTable.models.oSettings = {
 	 *  @default []
 	 */
 	"aLengthMenu": null,
-	
+
 	/**
 	 * Counter for the draws that the table does. Also used as a tracker for
 	 * server-side processing
@@ -677,21 +677,21 @@ DataTable.models.oSettings = {
 	 *  @default 0
 	 */
 	"iDraw": 0,
-	
+
 	/**
 	 * Indicate if a redraw is being done - useful for Ajax
 	 *  @type boolean
 	 *  @default false
 	 */
 	"bDrawing": false,
-	
+
 	/**
 	 * Draw index (iDraw) of the last error when parsing the returned data
 	 *  @type int
 	 *  @default -1
 	 */
 	"iDrawError": -1,
-	
+
 	/**
 	 * Paging display length
 	 *  @type int
@@ -714,7 +714,7 @@ DataTable.models.oSettings = {
 	 *  @private
 	 */
 	"_iDisplayEnd": 10,
-	
+
 	/**
 	 * Server-side processing - number of records in the result set
 	 * (i.e. before filtering), Use fnRecordsTotal rather than
@@ -736,7 +736,7 @@ DataTable.models.oSettings = {
 	 *  @private
 	 */
 	"_iRecordsDisplay": 0,
-	
+
 	/**
 	 * Flag to indicate if jQuery UI marking and classes should be used.
 	 * Note that this parameter will be set by the initialisation routine. To
@@ -744,14 +744,14 @@ DataTable.models.oSettings = {
 	 *  @type boolean
 	 */
 	"bJUI": null,
-	
+
 	/**
 	 * The classes to use for the table
 	 *  @type object
 	 *  @default {}
 	 */
 	"oClasses": {},
-	
+
 	/**
 	 * Flag attached to the settings object so you can check in the draw
 	 * callback if filtering has been done in the draw. Deprecated in favour of
@@ -761,7 +761,7 @@ DataTable.models.oSettings = {
 	 *  @deprecated
 	 */
 	"bFiltered": false,
-	
+
 	/**
 	 * Flag attached to the settings object so you can check in the draw
 	 * callback if sorting has been done in the draw. Deprecated in favour of
@@ -771,7 +771,7 @@ DataTable.models.oSettings = {
 	 *  @deprecated
 	 */
 	"bSorted": false,
-	
+
 	/**
 	 * Indicate that if multiple rows are in the header and there is more than
 	 * one unique cell per column, if the top one (true) or bottom one (false)
@@ -781,14 +781,14 @@ DataTable.models.oSettings = {
 	 *  @type boolean
 	 */
 	"bSortCellsTop": null,
-	
+
 	/**
 	 * Initialisation object that is used for the table
 	 *  @type object
 	 *  @default null
 	 */
 	"oInit": null,
-	
+
 	/**
 	 * Destroy callback functions - for plug-ins to attach themselves to the
 	 * destroy so they can clean up markup and events.
@@ -797,7 +797,24 @@ DataTable.models.oSettings = {
 	 */
 	"aoDestroyCallback": [],
 
-	
+	/**
+	* Update paging information
+	*  @type function
+	*/
+	"fnUpdatePagingInfo": function ()
+	{
+		if ( !this.oFeatures.bPaginate ) {
+			return;
+		}
+
+		this._iTotal = this.fnRecordsTotal();
+		this._iFilteredTotal = this.fnRecordsDisplay();
+		this._iPage = this._iDisplayLength === -1 ?
+			0 : Math.ceil( ( this._iDisplayStart + 1 ) / this._iDisplayLength );
+		this._iTotalPages = this._iDisplayLength === -1 ?
+			0 : Math.ceil( this._iFilteredTotal / this._iDisplayLength );
+	},
+
 	/**
 	 * Get the number of records in the current record set, before filtering
 	 *  @type function
@@ -810,7 +827,7 @@ DataTable.models.oSettings = {
 			return this.aiDisplayMaster.length;
 		}
 	},
-	
+
 	/**
 	 * Get the number of records in the current record set, after filtering
 	 *  @type function
@@ -823,7 +840,7 @@ DataTable.models.oSettings = {
 			return this.aiDisplay.length;
 		}
 	},
-	
+
 	/**
 	 * Set the display end point - aiDisplay index
 	 *  @type function
@@ -842,14 +859,14 @@ DataTable.models.oSettings = {
 			return this._iDisplayEnd;
 		}
 	},
-	
+
 	/**
 	 * The DataTables object for this table
 	 *  @type object
 	 *  @default null
 	 */
 	"oInstance": null,
-	
+
 	/**
 	 * Unique identifier for each instance of the DataTables object. If there
 	 * is an ID on the table node, then it takes that value, otherwise an


### PR DESCRIPTION
You mentioned in an issue I filed under the Plugins repo that you were planning on moving the fnPagingInfo plug-in into the core API: https://github.com/DataTables/Plugins/issues/12#issuecomment-16488722

Let me know if this is not what you meant.

Edit: Sorry about all the blank line additions/deletions. I'm still getting used to Vim D:
