### PR TITLE
Make fewer calls to $.inArray when assigning sort classes

### DIFF
--- a/media/src/core/core.columns.js
+++ b/media/src/core/core.columns.js
@@ -1,4 +1,3 @@
-
 /**
  * Add a column to the list used for the table with default values
  *  @param {object} oSettings dataTables settings object
@@ -114,23 +113,24 @@ function _fnColumnOptions( oSettings, iCol, oOptions )
 	}
 	
 	/* Check that the class assignment is correct for sorting */
-	if ( !oCol.bSortable ||
-		 ($.inArray('asc', oCol.asSorting) == -1 && $.inArray('desc', oCol.asSorting) == -1) )
+	var bAsc = $.inArray('asc', oCol.asSorting) !== -1;
+	var bDesc = !bAsc && $.inArray('desc', oCol.asSorting) !== -1;
+	if ( !oCol.bSortable || (!bAsc && !bDesc) )
 	{
 		oCol.sSortingClass = oSettings.oClasses.sSortableNone;
 		oCol.sSortingClassJUI = "";
 	}
-	else if ( $.inArray('asc', oCol.asSorting) == -1 && $.inArray('desc', oCol.asSorting) == -1 )
+	else if ( !bAsc && !bDesc )
 	{
 		oCol.sSortingClass = oSettings.oClasses.sSortable;
 		oCol.sSortingClassJUI = oSettings.oClasses.sSortJUI;
 	}
-	else if ( $.inArray('asc', oCol.asSorting) != -1 && $.inArray('desc', oCol.asSorting) == -1 )
+	else if ( bAsc && !bDesc )
 	{
 		oCol.sSortingClass = oSettings.oClasses.sSortableAsc;
 		oCol.sSortingClassJUI = oSettings.oClasses.sSortJUIAscAllowed;
 	}
-	else if ( $.inArray('asc', oCol.asSorting) == -1 && $.inArray('desc', oCol.asSorting) != -1 )
+	else if ( !bAsc && bDesc )
 	{
 		oCol.sSortingClass = oSettings.oClasses.sSortableDesc;
 		oCol.sSortingClassJUI = oSettings.oClasses.sSortJUIDescAllowed;


### PR DESCRIPTION
Only call once each to check to see sort ascending / sort descending is is active.  (And only check for the descending class if we didn't find the ascending class)

Should also lead to smaller minified code.
