### PR TITLE
Remove index from map call in pluck

### DIFF
--- a/media/src/api/api.base.js
+++ b/media/src/api/api.base.js
@@ -1,5 +1,4 @@
 
-
 (/** @lends <global> */function() {
 
 
@@ -411,7 +410,7 @@ _Api.prototype = /** @lends DataTables.Api */{
 
 	pluck: function ( prop )
 	{
-		return this.map( function ( el, i ) {
+		return this.map( function ( el ) {
 			return el[ prop ];
 		} );
 	},


### PR DESCRIPTION
Pluck isn't using the index, so it's safe to remove the ", i" from the function call passed to map.  Not much, but at least a few fewer bytes.
