### PR TITLE
Use jQuery.fn.prop to set a property of an element (instead of jQuery.fn.attr)

### DIFF
--- a/media/src/core/core.length.js
+++ b/media/src/core/core.length.js
@@ -1,5 +1,4 @@
 
-
 /**
  * Generate the node required for user display length changing
  *  @param {object} oSettings dataTables settings object
@@ -48,7 +47,7 @@ function _fnFeatureHtmlLength ( oSettings )
 	 * Set the length to the current display length - thanks to Andrea Pavlovic for this fix,
 	 * and Stefan Skopnik for fixing the fix!
 	 */
-	$('select option[value="'+oSettings._iDisplayLength+'"]', nLength).attr("selected", true);
+	$('select option[value="'+oSettings._iDisplayLength+'"]', nLength).prop("selected", true);
 	
 	$('select', nLength).bind( 'change.DT', function(e) {
 		var iVal = $(this).val();


### PR DESCRIPTION
It's deprecated and triggers a note since `jquery.migration`
