### PR TITLE
Fix for Fix for 151: Column searchablity can offset the column type index

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -2472,9 +2472,8 @@
 		// aData is passed in without the columns which are not searchable, so
 		// we need to be careful in getting the correct column type
 		for ( var i=0, len=aoColumns.length ; i<len ; i++ ) {
-			aData[idx] = _fnDataToSearch( aData[idx], aoColumns[i].sType );
-	
 			if ( aoColumns[i].bSearchable ) {
+				aData[idx] = _fnDataToSearch( aData[idx], aoColumns[i].sType );
 				idx++;
 			}
 		}

--- a/media/src/core/core.filter.js
+++ b/media/src/core/core.filter.js
@@ -317,9 +317,8 @@ function _fnBuildSearchRow( oSettings, aData )
 	// aData is passed in without the columns which are not searchable, so
 	// we need to be careful in getting the correct column type
 	for ( var i=0, len=aoColumns.length ; i<len ; i++ ) {
-		aData[idx] = _fnDataToSearch( aData[idx], aoColumns[i].sType );
-
 		if ( aoColumns[i].bSearchable ) {
+			aData[idx] = _fnDataToSearch( aData[idx], aoColumns[i].sType );
 			idx++;
 		}
 	}


### PR DESCRIPTION
In function _fnBuildSearchRow(), aData[idx] incorrectly got investigated even if aoColumns[i].bSearchable was false.

(If you're reviewing this commit, imagine that aoColumns[i].length ==
10 and aData.length == 1 and the first and only i where
aoColumns[i].bSearchable is true is i== 5. You'll notice that e.g.
aData[8] also gets investigated)

History: First there was this commit:

```
commit 065c2cc66b872c6964b7d31f12941f23e7f1f171
Date:   Thu Nov 1 21:45:48 2012 +0000

    Fix: Filtering wasn't correctly applying the `type` adjustments needed for the global filter. For example this meant that html was not stripped from 'html' type columns, resulting in filtering being done on html tags/attributes as well as the content.
```

It fixed e.g. this issue:
"How to search only non html content - DataTables forums"
http://www.datatables.net/forums/discussion/13667/how-to-search-only-non-html-content/p1

However, it was buggy, and then this got committed.

```
commit f3ce2e2d44db8eb43750435c55eb2551b2c6019e
Date:   Sat Feb 16 11:27:41 2013 +0000

    Fix 151: Column type was being offset when columns were not searchable
```

However, that requires this commit to work properly.
