### PR TITLE
fixing error when sorting on columns with html data

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -13007,7 +13007,7 @@
 		 */
 		"html-pre": function ( a )
 		{
-			return a.replace( /<.*?>/g, "" ).toLowerCase();
+			return (a==null)? a : a.replace( /<.*?>/g, "" ).toLowerCase();
 		},
 		
 		


### PR DESCRIPTION
Fixing Uncaught TypeError: Cannot call method 'replace' of null  when trying to sort a column that contains HTML data.
