### PR TITLE
Update jquery.dataTables.css

### DIFF
--- a/media/css/jquery.dataTables.css
+++ b/media/css/jquery.dataTables.css
@@ -1,4 +1,3 @@
-
 /*
  * Table
  */
@@ -146,7 +145,6 @@ table.dataTable tr.even td.sorting_3 { background-color: #F9F9FF; }
 .paging_full_numbers a.paginate_active {
 	border: 1px solid #aaa;
 	-webkit-border-radius: 5px;
-	-moz-border-radius: 5px;
 	border-radius: 5px;
 	padding: 2px 5px;
 	margin: 0 3px;


### PR DESCRIPTION
Border radius has been removed from firefox 13 and up. There are no current versions that support it.
