### PR TITLE
Add CSS class to length select element

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -2751,6 +2751,7 @@
 			'name':          tableId+'_length',
 			'aria-controls': tableId
 		} );
+        select.addClass( settings.oClasses.sLengthMenu);
 	
 		for ( var i=0, ien=lengths.length ; i<ien ; i++ ) {
 			select[0][ i ] = new Option( language[i], lengths[i] );
@@ -13321,6 +13322,7 @@
 		"sInfo": "dataTables_info",
 		"sPaging": "dataTables_paginate paging_", /* Note that the type is postfixed */
 		"sLength": "dataTables_length",
+        "sLengthMenu": "", /* Length menu element */
 		"sProcessing": "dataTables_processing",
 	
 		/* Sorting */


### PR DESCRIPTION
I was looking for a way to style the SELECT element from the length feature.
There is option to add a css class to the entire menu wrapper but not to the item itself. 
For bootstrap 3 styling the class "form-control" is required on this select element.

I added **sLengthMenu** to the classes which you can extend.

```
/* Default class modification */
    $.extend( $.fn.dataTableExt.oStdClasses, {
        "sLengthMenu": "form-control input-sm"
    } );
```
