### PR TITLE
[EASY PICK] Fixed package name in composer.json 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "DataTables/DataTables", 
+	"name": "datatables/datatables", 
 	"description": "DataTables is a plug-in for the jQuery Javascript library. It is a highly flexible tool, based upon the foundations of progressive enhancement, which will add advanced interaction controls to any HTML table.", 
 	"homepage": "http://www.datatables.net/",
 	"author": "SpryMedia", 


### PR DESCRIPTION
**packagist/composer requires a lowercase name**

With the former package name being DataTables/DataTables it is not possible to add this library to [packagist](http://packagist.org) which makes this file useless in it's current state.

Please note the [error message](http://img42.imageshack.us/img42/1079/ywi9.png)  when trying to [submit the package](https://packagist.org/packages/submit) to packagist.

"The package name DataTables/DataTables is invalid, it should not contain uppercase characters. We suggest using data-tables/data-tables instead."
