### PR TITLE
Support minifier license comment convetion

### DIFF
--- a/media/src/DataTables.js
+++ b/media/src/DataTables.js
@@ -1,4 +1,4 @@
-/**
+/*!
  * @summary     DataTables
  * @description Paginate, search and sort HTML tables
  * @version     1.10.0-dev


### PR DESCRIPTION
Many JS minifiers use the convention that comments starting with '/*!'
are preserverd as license comments. To help build tools do this easily
with DataTables, it should use this convention. This ensures the
license comment is preserved when using these tools.

From https://github.com/yui/yuicompressor/blob/master/README.md
C-style comments starting with /*! are preserved. This is useful with
comments containing copyright/license information.

From https://github.com/yui/yuglify
We need to support the /*! license comment blocks when minifying, so
we added a preprocessor to the code to pull them from the source, then
place them back when the minification is complete.
