### PR TITLE
Changing Copyright comment block to use /*! notation so it's not stripped when minified

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -1,4 +1,4 @@
-/**
+/*!
  * @summary     DataTables
  * @description Paginate, search and sort HTML tables
  * @version     1.10.0-dev


### PR DESCRIPTION
Due to recent issues with AHA website (http://www.weeklystandard.com/blogs/obamacare-website-violates-licensing-agreement-copyrighted-software_763666.html), it would be good to make sure this copyright statement is not stripped when minified.  Using the industry standard comment block, most (if not all) minifying libraries will not strip the comment block.

``` javascript
/*!
 * This will not get stripped due to the exclamation mark
 */
```
