### PR TITLE
Correct sProcessing bug on jquery.dataTables.js

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -4438,7 +4438,9 @@
 			// Use a timeout to allow the processing display to be shown.
 			setTimeout( function() {
 				_fnSortListener( settings, colIdx, e.shiftKey, callback );
-				_fnProcessingDisplay( settings, false );
+				if ( !settings.oFeatures.bServerSide ) {
+					_fnProcessingDisplay( settings, false );
+				}
 			}, 0 );
 		} );
 	}


### PR DESCRIPTION
When click on column header to sort data from server side, the sProcessing did not work. Now it's good (for me).
