### PR TITLE
Updated dependencies to work with jQuery 2

### DIFF
--- a/component.json
+++ b/component.json
@@ -6,6 +6,6 @@
 		"./media/css/jquery.dataTables.css"
 	],
 	"dependencies": {
-		"jquery": "~1.8.0"
+		"jquery": ">=1.7.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		}
 	],
 	"dependencies": {
-		"jquery": "1.4 - 1.8"
+		"jquery": ">=1.7"
 	},
 	"description": "DataTables enhances HTML tables with the ability to sort, filter and page the data in the table very easily. It provides a comprehensive API and set of configuration options, allowing you to consume data from virtually any data source.",
 	"keywords": [


### PR DESCRIPTION
Hi Allan,
thank for writing and maintaining DataTables!
I submitted this little change to allow to use the latest stable jQuery (2.0.3 as of now) in a stable version of DataTables (1.9.4). I know this change is done in development but we can't use it in production.
Is it possible that you push this change to 1.9.4? If you are planning to release 1.10 within next week or two then please disregard this request.

Thank you!
Tonya.
