### PR TITLE
Fixing big with undefined value in calculations

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -3590,6 +3590,9 @@
 		// will end up forcing the scrollbar to appear, making our measurements wrong for when we
 		// then hide it (end of this function), so add the header height to the body scroller.
 		if ( scroll.bCollapse && scrollY !== "" ) {
+			if(divBody.offsetHeight === undefined){
+				divBody.offsetHeight = 0;
+			}
 			divBodyStyle.height = (divBody.offsetHeight + header[0].offsetHeight)+"px";
 		}
 	


### PR DESCRIPTION
When the datatables is build dynamically, the initial state of divBody.offsetHeight is undefined and can not be used straight away in the displayBodyStyle.height calculation on line 3596. Setting its value to zero, will fix the problem.
