### PR TITLE
Adding "default direction" for doing multi-column sorting using the "orderData" option

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -4276,7 +4276,7 @@
 			aSort = [],
 			aiOrig = [],
 			aoColumns = settings.aoColumns,
-			aDataSort, iCol, sType, srcCol,
+			aDataSort, iCol, iDir, sType, srcCol,
 			fixed = settings.aaSortingFixed,
 			fixedObj = $.isPlainObject( fixed ),
 			nestedSort = [],
@@ -4314,13 +4314,14 @@
 	
 			for ( k=0, kLen=aDataSort.length ; k<kLen ; k++ )
 			{
-				iCol = aDataSort[k];
+				iCol = $.isArray(aDataSort[k]) ? aDataSort[k][0] : aDataSort[k];
+                                iDir = $.isArray(aDataSort[k]) ? aDataSort[k][1] : nestedSort[i][1];
 				sType = aoColumns[ iCol ].sType || 'string';
 	
 				aSort.push( {
 					src:       srcCol,
 					col:       iCol,
-					dir:       nestedSort[i][1],
+					dir:       iDir,
 					index:     nestedSort[i][2],
 					type:      sType,
 					formatter: DataTable.ext.type.order[ sType+"-pre" ]


### PR DESCRIPTION
slightly modified the _fnSortFlatten to allow for "default direction" for doing multi-column sorting, hope you would consider adding it, check for sanity.

Basically it will allow some some syntax like this orderData: [0, [2, 'asc'], 1, [3, 'desc'], .....]

Thanks.
