### PR TITLE
Fixes child rows bug

### DIFF
--- a/examples/api/row_details.html
+++ b/examples/api/row_details.html
@@ -66,7 +66,7 @@ $(document).ready(function() {
 	
 	// Add event listener for opening and closing details
 	$('#example tbody').on('click', 'td.details-control', function () {
-		var tr = $(this).parent('tr');
+		var tr = $(this).closest('tr');
 		var row = table.row( tr );
 
 		if ( row.child.isShown() ) {
@@ -180,7 +180,7 @@ $(document).ready(function() {
 	
 	// Add event listener for opening and closing details
 	$('#example tbody').on('click', 'td.details-control', function () {
-		var tr = $(this).parent('tr');
+		var tr = $(this).closest('tr');
 		var row = table.row( tr );
 
 		if ( row.child.isShown() ) {


### PR DESCRIPTION
When datatable is nested in another table the shown class is added to several tr elements which leads to problems with css styling, e.g. all lines show the open icon.
