### PR TITLE
Column Header widths troubles

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -3732,7 +3732,12 @@
 		// Read all widths in next pass
 		_fnApplyToChildren( function(nSizer) {
 			headerContent.push( nSizer.innerHTML );
-			headerWidths.push( _fnStringToCss( nSizer.style.width ) );
+			if ( !nSizer.style.width && $(nSizer).css('width') != "0px" ) {
+				headerWidths.push( _fnStringToCss( $(nSizer).css('width') ) );
+			}
+			else {
+				headerWidths.push( _fnStringToCss( nSizer.style.width ) );
+			}
 		}, headerSrcEls );
 	
 		// Apply all widths in final pass
@@ -3748,7 +3753,12 @@
 			_fnApplyToChildren( zeroOut, footerSrcEls );
 	
 			_fnApplyToChildren( function(nSizer) {
-				footerWidths.push( _fnStringToCss( nSizer.style.width ) );
+				if ( !nSizer.style.width && $(nSizer).css('width') != "0px" ) {
+					footerWidths.push( _fnStringToCss( $(nSizer).css('width') ) );
+				}
+				else {
+					footerWidths.push( _fnStringToCss( nSizer.style.width ) );
+				}
 			}, footerSrcEls );
 	
 			_fnApplyToChildren( function(nToSize, i) {


### PR DESCRIPTION
Fixes:
- widths like 30px/30em are internally stored as 30p/30e
- css width on header ignored (attribute still works)
- header calculation wrong when css box-sizinig: border-box and scrolling enabled

Set up that's broken:
http://live.datatables.net/kivekin/2/
Same Set up including my fix:
http://live.datatables.net/kivekin/3/
