### PR TITLE
Improved last page calculation.

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -5121,7 +5121,7 @@
 		/* If we have space to show extra rows (backing up from the end point - then do so */
 		if ( end === settings.fnRecordsDisplay() )
 		{
-			start = end - len;
+			start = end - (end % len);
 		}
 	
 		if ( len === -1 || start < 0 )


### PR DESCRIPTION
Improved last page calculation when page size is changed on last page.
e.g. Suppose there are total 12 records and page size is set to 5 records/page. Go to last page, which should be 3, change page size to 10. Page#2 should be selected and it should show 2 records on it.
