### PR TITLE
fix for misaligned footer

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -3599,11 +3599,16 @@
 				$(_div, { 'class': classes.sScrollFoot } )
 					.css( {
 						overflow: 'hidden',
+						position: 'relative',
 						border: 0,
 						width: scrollX ? size(scrollX) : '100%'
 					} )
 					.append(
 						$(_div, { 'class': classes.sScrollFootInner } )
+							.css( {
+								'box-sizing': 'content-box',
+								width: scroll.sXInner || '100%'
+							} )
 							.append(
 								footerClone
 									.removeAttr('id')


### PR DESCRIPTION
Footer was previously misaligned (even though it is working well for the header) when scrollX and scrollY are enabled, and when the vertical scrollbar is present and the horizontal scrollbar is placed at the extreme right.

FIX: Just copied the header's code that was missing for footer.
