### PR TITLE
allow render function to assume direct control of updating cell DOM

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -1612,7 +1612,7 @@
 				// Need to create the HTML if new, or if a rendering function is defined
 				if ( !nTrIn || oCol.mRender || oCol.mData !== i )
 				{
-					var html = nTd.innerHTML;
+					var html = _fnGetCellData( oSettings, iRow, i, 'display' );
 					if (html) {
 						nTd.innerHTML = html;
 					}

--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -1457,7 +1457,10 @@
 						cell.removeChild( cell.firstChild );
 					}
 	
-					cells[i].innerHTML = _fnGetCellData( settings, rowIdx, i, 'display' );
+					var html = _fnGetCellData( settings, rowIdx, i, 'display' );
+					if (html) {
+						cells[i].innerHTML = html;
+					}
 				}
 			}
 		}
@@ -1609,7 +1612,10 @@
 				// Need to create the HTML if new, or if a rendering function is defined
 				if ( !nTrIn || oCol.mRender || oCol.mData !== i )
 				{
-					nTd.innerHTML = _fnGetCellData( oSettings, iRow, i, 'display' );
+					var html = nTd.innerHTML;
+					if (html) {
+						nTd.innerHTML = html;
+					}
 				}
 	
 				/* Add user defined class */


### PR DESCRIPTION
This is a quick proof-of-concept patch for the idea of allowing the
render function to take full control of rendering content within a cell.
Instead of returning HTML for DataTables to add to the cell, the render
function updates the DOM directly and returns null to indicate that
touching the innerHTML is unnecessary.

This allows the view rendering code to retain references to actual dom
elements on the page for event handling and UI binding.

As an example, my application is using a Backbone Marionette view for
each cell's contents, binding the view to the td created by DataTables
and then rendering to it directly.

I first tried using column.createdCell, which gives convenient access to
the cell node, but that the initial drawing; subsequent re-displays only
call data and/or display and then overwrite the innerHTML, orphaning the
previous elements.

I don't really expect this patch to be accepted directly but I wanted to
open discussion about providing some method to accomplish direct
rendering control.

Issues to considering
- the td node could be better exposed to the rendering function

Right now, I have to dig out of the meta parameter:

  meta.settings.aoData[meta.row].anCells[meta.col]

but it could be passed as a parameter, or perhaps added as e.g.
meta.node. Alternatively, the render function could be permitted to
create and return the node itself.
- a better way to signal that the render function is handling the
  rendering and that DataTables should not modify innerHTML

Using "null" is kinda dirty.  Could be signaled by return type
(HTMLElement) or by using a different function than column.render which
always handles rendering
