### PR TITLE
Allow for inserting html elements and nodes into td (using mRender).

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -1564,6 +1564,29 @@
 			cells: tds
 		};
 	}
+
+	/**
+	 * Returns true if it is a DOM node
+	 *  @param {object} o
+	 */
+	function _fnIsNode( o ){
+		return (
+			typeof Node === "object" ? o instanceof Node :
+			o && typeof o === "object" && typeof o.nodeType === "number" && typeof o.nodeName==="string"
+		);
+	}
+
+	/**
+	 * Returns true if it is a DOM element
+	 *  @param {object} o
+	 */
+	function _fnIsElement( o ){
+		return (
+			typeof HTMLElement === "object" ? o instanceof HTMLElement : //DOM2
+			o && typeof o === "object" && o !== null && o.nodeType === 1 && typeof o.nodeName==="string"
+		);
+	}
+
 	/**
 	 * Create a new TR element (and it's TD children) for a row
 	 *  @param {object} oSettings dataTables settings object
@@ -1609,7 +1632,14 @@
 				// Need to create the HTML if new, or if a rendering function is defined
 				if ( !nTrIn || oCol.mRender || oCol.mData !== i )
 				{
-					nTd.innerHTML = _fnGetCellData( oSettings, iRow, i, 'display' );
+					var cellData = _fnGetCellData( oSettings, iRow, i, 'display' );
+					if( _fnIsNode( cellData ) || _fnIsElement( cellData ) )
+					{
+						$(nTd).append( cellData );
+					} else
+					{
+						nTd.innerHTML = _fnGetCellData( oSettings, iRow, i, 'display' );
+					}
 				}
 	
 				/* Add user defined class */


### PR DESCRIPTION
A developer may way want to append an element or node in cell data rather than only html. This is particularly useful when attempting to retain binding connections between the dom and an object. For example, useful to bind a Backbone View object to a dom node; otherwise, without this, using to html() on the backbone view destroys the binding connection.

The two new functions used to test isElement and isNode were both taken from StackOverflow http://stackoverflow.com/questions/384286/javascript-isdom-how-do-you-check-if-a-javascript-object-is-a-dom-object.
