### PR TITLE
Fix reference to (possibly undefined) global variable jQuery

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -8815,7 +8815,7 @@
 	 */
 	DataTable.tables = DataTable.fnTables = function ( visible )
 	{
-		return jQuery.map( DataTable.settings, function (o) {
+		return $.map( DataTable.settings, function (o) {
 			if ( !visible || (visible && $(o.nTable).is(':visible')) ) {
 				return o.nTable;
 			}


### PR DESCRIPTION
We should be using the local copy of jQuery `$` like everywhere else instead of relying on a global variable which may or may not exist.
