### PR TITLE
Use parseInt in fnFormatNumber to Remove Leading Zeros

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -10379,10 +10379,10 @@
 		 *    } );
 		 */
 		"fnFormatNumber": function ( toFormat ) {
-			return toFormat.toString().replace(
+			return parseInt(toFormat.toString().replace(
 				/\B(?=(\d{3})+(?!\d))/g,
 				this.oLanguage.sThousands
-			);
+			), 10);
 		},
 	
 	


### PR DESCRIPTION
DataTables often adds leading zeros to pagination info, for example:

> Showing 1 to 05 of 83 entries

Here is a fix.