### PR TITLE
Cant use datatables with webpack BowerWebpackPlugin #513

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,20 @@
 {
 	"name": "datatables",
-	"version": "1.10.6-dev",
+	"version": "1.10.7-dev",
 	"main": [
 		"media/js/jquery.dataTables.js",
 		"media/css/jquery.dataTables.css",
-		"media/images/*.png"
+		"media/images/back_disabled.png",
+		"media/images/back_enabled.png",
+		"media/images/back_enabled_hover.png",
+		"media/images/forward_disabled.png",
+		"media/images/forward_enabled.png",
+		"media/images/forward_enabled_hover.png",
+		"media/images/sort_asc.png",
+		"media/images/sort_asc_disabled.png",
+		"media/images/sort_both.png",
+		"media/images/sort_desc.png",
+		"media/images/sort_desc_disabled.png"
 	],
 	"dependencies": {
 		"jquery": ">=1.7.0"


### PR DESCRIPTION
bower.json has a wildcard character in 'main' section for images: "media/images/*.png".
this leads to the following error:

ERROR in DataTables (bower component)
Module not found: Error: Cannot resolve 'file' or 'directory' ./media/images/*.png in bower_components\DataTables
@ DataTables (bower component) 3:0-31

According to bower specification its not allowed to use a wildcard characters in main sections, instead files should be listed manually
