### PR TITLE
Register DataTables as an Anonymous AMD Module

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -31,7 +31,7 @@
 
 	if ( typeof define === 'function' && define.amd ) {
 		// Define as an AMD module if possible
-		define( 'datatables', ['jquery'], factory );
+		define( ['jquery'], factory );
 	}
     else if ( typeof exports === 'object' ) {
         // Node/CommonJS


### PR DESCRIPTION
This allows users to choose a name for DataTables in their RequireJS configs instead of being forced to call it "datatables".