### PR TITLE
Update jquery.dataTables.js

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -4180,10 +4180,11 @@
 	
 			for ( i=0 ; i<visibleColumns.length ; i++ ) {
 				column = columns[ visibleColumns[i] ];
-	
-				headerCells[i].style.width = column.sWidthOrig !== null && column.sWidthOrig !== '' ?
-					_fnStringToCss( column.sWidthOrig ) :
-					'';
+                if(typeof headerCells[i] != "undefined"){
+                    headerCells[i].style.width = column.sWidthOrig !== null && column.sWidthOrig !== '' ?
+                        _fnStringToCss( column.sWidthOrig ) :
+                        '';
+                }
 			}
 	
 			// Find the widest cell for each column and put it into the table
@@ -15020,4 +15021,3 @@
 }));
 
 }(window, document));
-


### PR DESCRIPTION
when using scrollX or scrollY, the headerCells array contains nulls and breaks (particularly when having hidden columns)

 here we simply check for undefined to allow it to work
