### PR TITLE
fix for incorrect calculation in _fnBrowserDetect

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -519,7 +519,7 @@
 		// Scrolling feature / quirks detection
 		var n = $('<div/>')
 			.css( {
-				position: 'absolute',
+				position: 'fixed',
 				top: 0,
 				left: 0,
 				height: 1,


### PR DESCRIPTION
when body's position is changed (left: 375px) _fnBrowserDetect incorrecly calculates offsets. thus header is a bit misaligned. commit changes test object's position to fixed. in this case it's position will
be relative to the viewport not to the body.
this fixes #594.