### PR TITLE
Fix calculating column width

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -3798,6 +3798,7 @@
 			headerWidths=[], footerWidths=[],
 			headerContent=[],
 			idx, correction, sanityWidth,
+			newHeight,
 			zeroOut = function(nSizer) {
 				var style = nSizer.style;
 				style.paddingTop = "0";
@@ -3855,7 +3856,11 @@
 		// will end up forcing the scrollbar to appear, making our measurements wrong for when we
 		// then hide it (end of this function), so add the header height to the body scroller.
 		if ( scroll.bCollapse && scrollY !== "" ) {
-			divBodyStyle.height = (divBody[0].offsetHeight + header[0].offsetHeight)+"px";
+			newHeight = divBody[0].offsetHeight + header[0].offsetHeight;
+			divBodyStyle.height = newHeight+"px";
+			// correction is required if divBody has border.
+			newHeight += newHeight - divBody[0].offsetHeight;
+			divBodyStyle.height = newHeight+"px";
 		}
 	
 		// Size the table as a whole

--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -3907,15 +3907,15 @@
 		// Hidden header should have zero height, so remove padding and borders. Then
 		// set the width based on the real headers
 	
-		// Apply all styles in one pass
-		_fnApplyToChildren( zeroOut, headerSrcEls );
-	
 		// Read all widths in next pass
 		_fnApplyToChildren( function(nSizer) {
 			headerContent.push( nSizer.innerHTML );
 			headerWidths.push( _fnStringToCss( $(nSizer).css('width') ) );
 		}, headerSrcEls );
 	
+		// Apply all styles in one pass
+		_fnApplyToChildren( zeroOut, headerSrcEls );
+		
 		// Apply all widths in final pass
 		_fnApplyToChildren( function(nToSize, i) {
 			nToSize.style.width = headerWidths[i];


### PR DESCRIPTION
With "scrollY" and "scrollCollapse: true" options and with custom CSS styling, determining table size fails in some cases.
In that case, inner table has 100% width (no space for scrollbars) but scrollbars appear on the table.

A sample based on 1.10.7.
http://jsfiddle.net/kzmi/52qzczL9/

With my workaround. (only replaced jquery.dataTables.js with my version)
http://jsfiddle.net/kzmi/e53LjLpx/

This workaround are based on 1.10.7, but the issue seems to be still there in 1.10.8-dev.