### PR TITLE
A bad if statement was causing column widths to not be calculated correctly

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -4183,7 +4183,10 @@
 			for ( i=0 ; i<columnCount ; i++ ) {
 				var colIdx = _fnVisibleToColumnIndex( oSettings, i );
 	
-				if ( colIdx ) {
+			    // The below if statement was introduced in DataTables 1.10.9.  It was incorrect because it checked: if ( colIdx )
+			    // That then returned false when the index of the first column was 0.  Adding "!= null" fixed the issue.  
+				// The behavior was that column widths were not correct in IE for tables that had not been shown when their data was loaded.
+				if ( colIdx != null ) {
 					columns[ colIdx ].sWidth = _fnStringToCss( headerCells.eq(i).width() );
 				}
 			}


### PR DESCRIPTION
When the data table, or its container, have not yet been shown when the data is loaded the column widths are not calculated correctly in IE.  This bug was introduced in 1.10.9.  Prior to that column widths were correct even when the table was not yet shown.

The culprit was a single if statement.

This was tested against IE 11.  The behavior can be observed in this fiddle: https://jsfiddle.net/foraydev/onux4rwx/6/

Make sure the window is wide enough.  The Name column will be too wide and the others will be crammed together.  <th> elements for all columns except the first will be set to 0px.
