### PR TITLE
Add orderable and searchable column-selector

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -8329,7 +8329,7 @@
 					case 'visible':
 					case 'orderable':
 					case 'searchable':
-						var rlname = match[2] === 'orderable' ? 'sortable' : orderable;
+						var rlname = match[2] === 'orderable' ? 'sortable' : match[2];
 						var setting = 'b' + rlname[0].toUpperCase() + rlname[0].slice(1);
 						// No index given, return all matches
 						if (match[1] === "*") {

--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -8329,7 +8329,8 @@
 					case 'visible':
 					case 'orderable':
 					case 'searchable':
-						var setting = 'b' + match[2][0].toUpperCase() + match[2][0].slice(1);
+						var rlname = match[2] === 'orderable' ? 'sortable' : orderable;
+						var setting = 'b' + rlname[0].toUpperCase() + rlname[0].slice(1);
 						// No index given, return all matches
 						if (match[1] === "*") {
 							return _fnGetColumns( settings, setting );


### PR DESCRIPTION
After [my question on the forum](https://datatables.net/forums/discussion/30793/get-column-settings-from-the-api), here an idea of implementing the posibility to filter columns on the API on their settings.  

It would allow:
```js
var lastSearchables = this.api.columns("-1:searchable");
var firstOrderable = this.api.columns("0:orderable");
var allVisibles = this.api.columns("*:visible");
```

I wasn't sure if there is already a function that convert `1.10` names to `1.9`. But I'll rewrite what I made because I just noticed it's `bSortable` and not `bOrderable`.

Tell me what you think about it.