### PR TITLE
Add all files in media/ to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,8 @@
 	"title": "DataTables",
 	"main": "media/js/jquery.dataTables",
 	"files": [
-		"media/js/jquery.dataTables.js",
-		"media/js/jquery.dataTables.min.js",
-		"media/css/jquery.dataTables.css",
-		"media/css/jquery.dataTables.min.css",
+		"media/css",
+		"media/js",
 		"media/images"
 	],
 	"license": "MIT",


### PR DESCRIPTION
Currently only `jquery.dataTables*` are included in npm package, and UI framework specified files (like `dataTables.bootstrap.js`, `dataTables.bootstrap.css`) are not. This makes people using these UI frameworks impossible to use npm package as dependency.

This pull request add all files in `media/` folder to npm package.