### PR TITLE
Improve throttle function

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -1602,27 +1602,17 @@
 		throttle: function ( fn, freq ) {
 			var
 				frequency = freq !== undefined ? freq : 200,
-				last,
-				timer;
+				timer = 0;
 	
 			return function () {
 				var
 					that = this,
-					now  = +new Date(),
 					args = arguments;
-	
-				if ( last && now < last + frequency ) {
-					clearTimeout( timer );
-	
-					timer = setTimeout( function () {
-						last = undefined;
-						fn.apply( that, args );
-					}, frequency );
-				}
-				else {
-					last = now;
+					
+				clearTimeout( timer );
+				timer = setTimeout(function() {
 					fn.apply( that, args );
-				}
+				}, frequency);
 			};
 		},
 	


### PR DESCRIPTION
The current throttle function works as follows:

* With a `fn` function and a `delay` (ms) arguments
* If the function has not been called, it calls `fn` function
* The function can't be called after `delay` ms 

The change:

* The function `fn` isn't called in the first call

One example using searchDelay:

* Old way. If user types `Hello`, DataTables will search content with `H` (first call), and `Hello` (after `delay` ms)
* New way: If user types `Hello`, DataTables will search content with `Hello` (after `delay` ms)