### PR TITLE
[FIX] sUrl undefined making ajax request to self

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -1101,7 +1101,7 @@
 			var oLanguage = oSettings.oLanguage;
 			$.extend( true, oLanguage, oInit.oLanguage );
 			
-			if ( oLanguage.sUrl !== "" )
+			if ( typeof oLanguage.sUrl !== 'undefined' && oLanguage.sUrl !== "" )
 			{
 				/* Get the language definitions from a file - because this Ajax call makes the language
 				 * get async to the remainder of this function we use bInitHandedOff to indicate that


### PR DESCRIPTION
Setting language to NULL generated additional ajax request to current url.

The server while requesting by AJAX responds in ajax template and that is cached, when doing "back" in browser it showed the wrong ajax type page.

Did spend 4h  tracing "why there is additional ajax request to current page" that ended ended up to language field set to null/undefined.
