### PR TITLE
All files are subject to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,8 @@
 	"title": "DataTables",
 	"main": "media/js/jquery.dataTables",
 	"files": [
-		"media/js/jquery.dataTables.js",
-		"media/js/jquery.dataTables.min.js",
-		"media/css/jquery.dataTables.css",
-		"media/css/jquery.dataTables.min.css",
+		"media/js",
+		"media/css",
 		"media/images"
 	],
 	"license": "MIT",


### PR DESCRIPTION
I am using uikit with CSS.
But if you install datatables with npm, css and js such as uikit are not attached.
Therefore, I would like to add a setting that gives all the files.