### PR TITLE
Bug Fix events on inner elements overriden by the existence of a custom render function

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -3087,10 +3087,13 @@
 				cells.push( nTd );
 	
 				// Need to create the HTML if new, or if a rendering function is defined
+				// and it's return value is non null
 				if ( (!nTrIn || oCol.mRender || oCol.mData !== i) &&
 					 (!$.isPlainObject(oCol.mData) || oCol.mData._ !== i+'.display')
 				) {
-					nTd.innerHTML = _fnGetCellData( oSettings, iRow, i, 'display' );
+					var cellData = _fnGetCellData( oSettings, iRow, i, 'display' );
+					if ( cellData !== null )
+						nTd.innerHTML = cellData;
 				}
 	
 				/* Add user defined class */


### PR DESCRIPTION
This addresses the following scenario:

I am adding existing (non-rendered to the DOM) TRs to DT with events attached to their children.

I want a custom render function for providing filter and sort data, but not display data. If there is a custom render function it overrides all data including display data and overwrites the original cell content (even if the data is unchanged) which results in the fact that events of children inside the cell are lost.

This could be prevented if the render function can signal DT that it doesn’t want to override the data and it wants to use the original display data. Returning `undefined` is a good signal.

To address this issue, before overwriting the innerData of a cell using the display data from the custom render function you can check whether the data is `null` (`undefined` gets turned into `null` at this point).

And for all intents and purposes there is no point in overwriting the cell content with `null` or `undefined`. Of course overwriting it with an empty string `””` works correctly and would replace the display data (so does `null`). 