### PR TITLE
fix bug with "Next" pager button

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -4906,8 +4906,8 @@
 	function _fnPageChange ( settings, action, redraw )
 	{
 		var
-			start     = settings._iDisplayStart,
-			len       = settings._iDisplayLength,
+			start     = Number(settings._iDisplayStart),
+			len       = Number(settings._iDisplayLength),
 			records   = settings.fnRecordsDisplay();
 	
 		if ( records === 0 || len === -1 )


### PR DESCRIPTION
"Next" button did not work correctly when you have more then 10 pages.