### PR TITLE
Make jquery a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"media/images"
 	],
 	"license": "MIT",
-	"dependencies": {
+	"peerDependencies": {
 		"jquery": ">=1.7"
 	},
 	"author": {


### PR DESCRIPTION
Plugins should specify jQuery as a peer dependency rather than a dependency (https://nodejs.org/en/blog/npm/peer-dependencies/).

Yarn is having issues resolving the correct version of jquery to install when it is specified as a dependency (ie. it is installing 2 versions rather than 1).