### PR TITLE
Wjonker85 patch 1

### DIFF
--- a/examples/server_side/scripts/ids-arrays.php
+++ b/examples/server_side/scripts/ids-arrays.php
@@ -64,7 +64,8 @@ $sql_details = array(
 	'user' => '',
 	'pass' => '',
 	'db'   => '',
-	'host' => ''
+	'host' => '',
+	'charset' => 'utf8'
 );
 
 

--- a/examples/server_side/scripts/ids-objects.php
+++ b/examples/server_side/scripts/ids-objects.php
@@ -63,7 +63,8 @@ $sql_details = array(
 	'user' => '',
 	'pass' => '',
 	'db'   => '',
-	'host' => ''
+	'host' => '',
+	'charset' =>  'utf8'
 );
 
 

--- a/examples/server_side/scripts/ssp.class.php
+++ b/examples/server_side/scripts/ssp.class.php
@@ -387,7 +387,7 @@ class SSP {
 	{
 		try {
 			$db = @new PDO(
-				"mysql:host={$sql_details['host']};dbname={$sql_details['db']}",
+				"mysql:host={$sql_details['host']};dbname={$sql_details['db']};charset={$sql_details['charset']}",
 				$sql_details['user'],
 				$sql_details['pass'],
 				array( PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION )


### PR DESCRIPTION
When not specifying the charset the json response might be empty. This happens for characters like Ø and Ý.

This problem is discussed before here : https://datatables.net/forums/discussion/21242/invalid-json-response-when-adding-some-utf-8-characters. The solution in that post is to specify the charset utf8 explicitly. 

This simple patch makes is possible to specify the charset explicitly, with the default in examples for utf8.

I have currently no resources for a example.

I acknowledge that this contribution is offered under and can be made available under the project's existing license (MIT).