### PR TITLE
Specify UTF-8 encoding in PDO connect

### DIFF
--- a/examples/server_side/scripts/ssp.class.php
+++ b/examples/server_side/scripts/ssp.class.php
@@ -401,7 +401,7 @@ class SSP {
 	{
 		try {
 			$db = @new PDO(
-				"mysql:host={$sql_details['host']};dbname={$sql_details['db']}",
+				"mysql:host={$sql_details['host']};dbname={$sql_details['db']};charset=utf8",
 				$sql_details['user'],
 				$sql_details['pass'],
 				array( PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION )


### PR DESCRIPTION
Specify UTF-8 encoding in PDO connect in order to correct the resulting array for json_encode in > PHP7.1