### PR TITLE
JSON data has to be defined to test for errors

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -3886,7 +3886,7 @@
 		var baseAjax = {
 			"data": data,
 			"success": function (json) {
-				var error = json.error || json.sError;
+				var error = typeof json == 'undefined' || json.error || json.sError;
 				if ( error ) {
 					_fnLog( oSettings, 0, error );
 				}


### PR DESCRIPTION
Robustness: `json` variable might be undefined.

Firefox 68-78+ (Windows, Mac) calls the success function even when page is unloading.