### PR TITLE
Update license.txt

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -1,5 +1,6 @@
-Copyright (c) 2008-2015 SpryMedia Limited
-http://datatables.net
+The MIT License (MIT)
+
+Copyright (c) 2008-present, SpryMedia Limited
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
GitHub does not currently recognize this project as MIT.  It is very sensitive to the actual body text and formatting.

This change makes the text consistent with [VueJS License](https://github.com/vuejs/vue/blob/dev/LICENSE)