### PR TITLE
Remove workaround for old WebKit/Blink

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -3142,10 +3142,6 @@
 	
 			_fnCallbackFire( oSettings, 'aoRowCreatedCallback', null, [nTr, rowData, iRow, cells] );
 		}
-	
-		// Remove once webkit bug 131819 and Chromium bug 365619 have been resolved
-		// and deployed
-		row.nTr.setAttribute( 'role', 'row' );
 	}
 	
 	


### PR DESCRIPTION
The referenced bugs were fixed over 5 years ago:

https://bugs.webkit.org/show_bug.cgi?id=131819
https://bugs.chromium.org/p/chromium/issues/detail?id=365619