### PR TITLE
Add ID to input filter & use for attribute in Label

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -4179,7 +4179,8 @@
 		var language = settings.oLanguage;
 		var previousSearch = settings.oPreviousSearch;
 		var features = settings.aanFeatures;
-		var input = '<input type="search" class="'+classes.sFilterInput+'"/>';
+		var inputFilterId = tableId + '_input_filter';
+		var input = '<input type="search" id="' + inputFilterId + '" class="'+classes.sFilterInput+'"/>';
 	
 		var str = language.sSearch;
 		str = str.match(/_INPUT_/) ?
@@ -4190,7 +4191,7 @@
 				'id': ! features.f ? tableId+'_filter' : null,
 				'class': classes.sFilter
 			} )
-			.append( $('<label/>' ).append( str ) );
+			.append( $('<label for="' + inputFilterId + '" />' ).append( str ) );
 	
 		var searchFn = function() {
 			/* Update all other filter input elements for the new display */


### PR DESCRIPTION
On data tables the label in the data table search is not associated programmatically with the search field.

## Current
Although the field has a visible label, the label is not programmatically associated with the search field. This can cause screen readers to improperly label the field when reading to the user.

`<label>Search<input type="search" class="" placeholder="" aria-controls="datatable"></label>`

## Expected
`<label for="search_id">Search<input id="search_id" type="search" class="" placeholder="" aria-controls="datatable"></label>`

