### PR TITLE
Avoid Chrome to autocomplete in search field

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -4179,7 +4179,7 @@
 		var language = settings.oLanguage;
 		var previousSearch = settings.oPreviousSearch;
 		var features = settings.aanFeatures;
-		var input = '<input type="search" class="'+classes.sFilterInput+'"/>';
+		var input = '<form autocomplete="off"><input type="search" class="'+classes.sFilterInput+'"/></form>';
 	
 		var str = language.sSearch;
 		str = str.match(/_INPUT_/) ?


### PR DESCRIPTION
In the last months I have seen a lot of users of the platforms we build and use datatables where Chrome browser starts to autofill the input search field of all datatables as it is a login field.

I have been successfully replicated this behaviour with next steps:

1. Enable autocomplete functions in Chrome
2. Using the web application where datatables is installed, I create an account for a new user filling a standard user form.
3. Chrome ask to save the credentials for future logins, and I click Yes
4. From that moment all datatables with a search form inside the web application are autocompleted wit the email I use to create the account.
5. The result is always an empty table, because the search box is already filled with data (the email address) that don't correspond to the table

The only way I found to prevent this is to wrap the input html filed with a form tag and autocomplete="off" attribute directly on the datatables.js source code. I found some articles that suggest to to this with jquery inside the "initcomplete" function when datatablles finished rendering, but it still fails. I think Chrome is autofilling the field before initcomplete function is triggered, and at that moment it is too late.

I tested the search functionality after wrapping the field with the form tag and it works ok, I don't detect any problem trying to search elements in the table, and the problem with Chrome is gone.

Is it possible to wrap the input field with the form tag?