### PR TITLE
fix: correct default value that was wrong

### DIFF
--- a/media/js/jquery.dataTables.js
+++ b/media/js/jquery.dataTables.js
@@ -11336,7 +11336,7 @@
 				 * sorted descending by activing the column (click or return when focused).
 				 * Note that the column header is prefixed to this string.
 				 *  @type string
-				 *  @default : activate to sort column ascending
+				 *  @default : activate to sort column descending
 				 *
 				 *  @dtopt Language
 				 *  @name DataTable.defaults.language.aria.sortDescending


### PR DESCRIPTION
Fixing the default value that was wrong in the documentation for the sSortDescending field.